### PR TITLE
refactor: use centralized authApi in WelcomePage and update API URL

### DIFF
--- a/Frontend/src/Pages/WelcomePage.js
+++ b/Frontend/src/Pages/WelcomePage.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import './WelcomePage.css';
 import RegBird from '../assets/Images/RegBird.png';
 import { useNavigate } from 'react-router-dom';
-import axios from '../api/axiosConfig'; 
+import { resendVerificationEmail } from '../api/auth/authApi';
 
 function WelcomePage() {
     const navigate = useNavigate();
@@ -21,20 +21,24 @@ function WelcomePage() {
     };
 
     const handleResendVerification = async () => {
-        try {
-            setResendMessage('Skickar verifieringslänk...');
-            await axios.post('/api/auth/resend-verification', { email });
+        setResendMessage('Skickar verifieringslänk...');
+    
+        // Call the API function and get the status and message from the response
+        const { status, message } = await resendVerificationEmail(email);
+    
+        // Check response to show the appropriate message based on status
+        if (status === 200) {
             setResendMessage('En ny verifieringslänk har skickats. Kontrollera din e-post.');
             setResendMessageType('success');
-        } catch (error) {
-            if (error.response && error.response.status === 429) {
-                setResendMessage('Vänligen vänta några minuter innan du försöker igen.');
-            } else {
-                setResendMessage('Det gick inte att skicka verifieringslänken. Försök igen senare.');
-            }
+        } else if (status === 429) {
+            setResendMessage('Vänligen vänta några minuter innan du försöker igen.');
+            setResendMessageType('error');
+        } else {
+            setResendMessage(message || 'Det gick inte att skicka verifieringslänken. Försök igen senare.');
             setResendMessageType('error');
         }
     };
+    
 
     return (
         <div className="registration-container">

--- a/Frontend/src/api/auth/authApi.js
+++ b/Frontend/src/api/auth/authApi.js
@@ -25,18 +25,16 @@ export const registerUser = async (userData) => {
  * @param {string} email - The email address to resend the verification link to
  * @returns {Promise} - Axios response promise
  */
+
 export const resendVerificationEmail = async (email) => {
     try {
-        const response = await axios.post('/api/auth/resend-verification', { email }, {
-            headers: {
-                'Content-Type': 'application/json',
-            },
-        });
-        return response.data; // Return the API response data
-
+        const response = await axios.post('/api/Registration/resend-verification', { email });
+        return { status: response.status, message: response.data.message };
     } catch (error) {
-        const errorMessage = error.response?.data?.message || `Failed to resend verification email: ${error.response?.statusText || 'Unknown error'}`;
-        throw new Error(errorMessage);
+        // If the response has an error status (e.g., 429), catch it here
+        const status = error.response?.status;
+        const message = error.response?.data?.message || 'Something went wrong';
+        return { status, message }; // Return status and message to handle in React
     }
 };
 
@@ -54,3 +52,5 @@ export const verifyEmail = async (token) => {
         throw new Error(errorMessage);
     }
 };
+
+


### PR DESCRIPTION
- Updated WelcomePage to use resendVerificationEmail from authApi instead of calling Axios directly
- Corrected API URL to point to the proper endpoint
- Improved error handling logic for 429 status in resendVerificationEmail, ensuring consistent user messaging