### PR TITLE
feat: Implement rate limiting with global and registration-specific p…

### DIFF
--- a/Backend/Backend.csproj
+++ b/Backend/Backend.csproj
@@ -8,16 +8,15 @@
     <UserSecretsId>a0a75577-22e0-4d07-ade2-629e75f17c81</UserSecretsId>
   </PropertyGroup>
 
-  <ItemGroup>
-    <!-- Include all SQL files in SqlCode folder, but treat them as 'None' -->
-    <None Include="SqlCode\**\*.sql" />
-  </ItemGroup>
-
+	<ItemGroup>
+		<Content Include="SqlCode\**\*.sql" />
+	</ItemGroup>
   <ItemGroup>
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="Dapper" Version="2.1.35" />
     <PackageReference Include="MailKit" Version="4.8.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.RateLimiting" Version="7.0.0-rc.2.22476.2" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols" Version="8.1.2" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.1.2" />
@@ -27,7 +26,7 @@
     <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.8.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.1" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.1.2" />

--- a/Backend/Controllers/RegistrationController.cs
+++ b/Backend/Controllers/RegistrationController.cs
@@ -1,13 +1,8 @@
-﻿using Backend.Models;
-using Microsoft.AspNetCore.Mvc;
+﻿using Backend.Helpers;
+using Backend.Models;
 using Backend.Services;
-using Backend.DTO;
-using System.IdentityModel.Tokens.Jwt;
-using Microsoft.IdentityModel.Tokens;
-using System.Text;
-using System;
-using System.Linq;
-using Backend.Helpers;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 
 namespace Backend.Controllers
 {
@@ -29,6 +24,7 @@ namespace Backend.Controllers
         }
 
         [HttpPost("register")]
+        [EnableRateLimiting("RegistrationPolicy")]
         public async Task<IActionResult> Register([FromBody] RegistrationModel userDto)
         {
             _logger.LogInformation("CAPTCHA token: {CaptchaToken}", userDto.CaptchaToken); // Log token for debugging


### PR DESCRIPTION
…olicies

- Added global rate limiting policy (10 requests per minute per IP) for all API endpoints.
- Defined a custom 'RegistrationPolicy' (3 requests per minute per IP) specifically for registration endpoints.
- Applied 'RegistrationPolicy' to the 'register' endpoint in RegistrationController.
- Ensured flexibility to adjust rate limits per endpoint as needed, improving API protection against excessive requests.