### PR TITLE
feat(websocket): introduce AuthWebSocketManager with concurrency handling and comprehensive tests

### DIFF
--- a/Backend.Tests/Backend.Tests.csproj
+++ b/Backend.Tests/Backend.Tests.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+	<AssemblyName>Backend.Tests</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,6 +20,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.12" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />

--- a/Backend.Tests/Fixtures/WebSocketTestCollection.cs
+++ b/Backend.Tests/Fixtures/WebSocketTestCollection.cs
@@ -1,0 +1,12 @@
+﻿using Xunit;
+
+namespace Backend.Tests.Fixtures
+{
+    [CollectionDefinition("WebSocket Test Collection")]
+    public class WebSocketTestCollection : ICollectionFixture<WebSocketFixture>
+    {
+        // This class has no code, and is never created. Its purpose is solely
+        // to be the place to apply [CollectionDefinition] and all the
+        // ICollectionFixture<> interfaces.
+    }
+}

--- a/Backend.Tests/Fixtures/WebSocketTestFixture.cs
+++ b/Backend.Tests/Fixtures/WebSocketTestFixture.cs
@@ -1,0 +1,167 @@
+﻿using Backend.Application.Interfaces.EmailServices;
+using Backend.Application.Interfaces.UserServices;
+using Backend.Application.Services.EmailServices;
+using Backend.Application.Services.UserServices;
+using Backend.Infrastructure.Data.Sql.Interfaces;
+using Backend.Infrastructure.Data.Sql.Provider;
+using Backend.Infrastructure.Interfaces;
+using Backend.Infrastructure.WebSockets;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Xunit;
+
+namespace Backend.Tests.Fixtures
+{
+    public class WebSocketFixture : IAsyncLifetime
+    {
+        public IHost Host { get; private set; }
+        public string ServerAddress { get; private set; }
+        private readonly int _port;
+
+        public WebSocketFixture()
+        {
+            _port = GetFreePort();
+            Host = Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder()
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseKestrel(options =>
+                    {
+                        options.Listen(IPAddress.Loopback, _port);
+                    });
+
+                    webBuilder.ConfigureServices(services =>
+                    {
+                        // Core services
+                        services.AddControllers();
+                        services.AddAuthentication("Test")
+                                .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>("Test", null);
+
+                        services.AddSingleton<AuthWebSocketManager>(); // Singleton service
+                        services.AddSingleton<IWebSocketManager>(sp => sp.GetRequiredService<AuthWebSocketManager>()); // Interface resolution
+                        services.AddHostedService(sp => sp.GetRequiredService<AuthWebSocketManager>()); // HostedService lifecycle
+
+
+                        // Other dependencies
+                        services.AddScoped<IUserServices, UserServices>();
+                        services.AddScoped<IUserSQLProvider, UserSQLProvider>();
+                        services.AddScoped<IEmailService, EmailService>();
+                        services.AddScoped<IUserTokenService, UserTokenService>();
+                        services.AddScoped<IEmailResetPasswordService, EmailResetPasswordService>();
+                    });
+
+                    webBuilder.ConfigureLogging(logging =>
+                    {
+                        logging.ClearProviders();
+                        logging.AddConsole();
+                        logging.SetMinimumLevel(LogLevel.Debug);
+                    });
+
+                    webBuilder.Configure(app =>
+                    {
+                        app.UseWebSockets();
+                        app.UseRouting();
+                        app.UseAuthentication();
+                        app.UseAuthorization();
+
+                        app.UseEndpoints(endpoints =>
+                        {
+                            endpoints.MapControllers();
+                            endpoints.Map("/ws/auth", async context =>
+                            {
+                                if (context.WebSockets.IsWebSocketRequest)
+                                {
+                                    var webSocket = await context.WebSockets.AcceptWebSocketAsync();
+                                    var webSocketManager = context.RequestServices.GetRequiredService<IWebSocketManager>();
+                                    await webSocketManager.HandleConnectionAsync(webSocket, context);
+                                }
+                                else
+                                {
+                                    context.Response.StatusCode = 400;
+                                }
+                            });
+                        });
+                    });
+                })
+                .Build();
+        }
+
+        private int GetFreePort()
+        {
+            using var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port;
+        }
+
+        public async Task InitializeAsync()
+        {
+            await Host.StartAsync();
+            ServerAddress = $"http://localhost:{_port}";
+            Console.WriteLine($"WebSocket test server started at: {ServerAddress}");
+        }
+
+        public async Task DisposeAsync()
+        {
+            Console.WriteLine("WebSocketFixture disposing. Stopping host...");
+            await Host.StopAsync();
+            Console.WriteLine("Host stopped cleanly.");
+            Host.Dispose();
+        }
+    }
+
+    // Mock Authentication Handler for testing
+    public class TestAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+    {
+        public TestAuthHandler(
+            IOptionsMonitor<AuthenticationSchemeOptions> options,
+            ILoggerFactory logger,
+            UrlEncoder encoder,
+            ISystemClock clock)
+            : base(options, logger, encoder, clock)
+        { }
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            // 1. Check the "Test-Auth" header first
+            if (!Request.Headers.ContainsKey("Test-Auth") || !bool.TryParse(Request.Headers["Test-Auth"], out var isTestAuth) || !isTestAuth)
+            {
+                return Task.FromResult(AuthenticateResult.Fail("Test-Auth header not present or false."));
+            }
+
+            // 2. Attempt to read user from the query string "?user=xxx"
+            var userFromQuery = Request.Query["user"].ToString();
+
+            // 3. If not present, fallback to "Test-User" header
+            if (string.IsNullOrEmpty(userFromQuery) && Request.Headers.ContainsKey("Test-User"))
+            {
+                userFromQuery = Request.Headers["Test-User"].ToString();
+            }
+
+            // 4. If still null or empty, default to "testuser"
+            if (string.IsNullOrEmpty(userFromQuery))
+            {
+                userFromQuery = "testuser";
+            }
+
+            // 5. Build the user identity with that user ID
+            var claims = new[] { new Claim("sub", userFromQuery) };
+            var identity = new ClaimsIdentity(claims, "Test");
+            var principal = new ClaimsPrincipal(identity);
+            var ticket = new AuthenticationTicket(principal, "Test");
+
+            return Task.FromResult(AuthenticateResult.Success(ticket));
+        }
+
+    }
+}

--- a/Backend.Tests/IntegrationTests/Services/WebSocketManagerIntegrationTest/WebSocketIntegrationTests.cs
+++ b/Backend.Tests/IntegrationTests/Services/WebSocketManagerIntegrationTest/WebSocketIntegrationTests.cs
@@ -1,0 +1,683 @@
+﻿using Backend.Infrastructure.Interfaces;
+using Backend.Tests.Fixtures;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using System.Net.WebSockets;
+using System.Text;
+using Xunit;
+using Moq;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Backend.Infrastructure.WebSockets;
+using Xunit.Sdk;
+
+namespace Backend.Tests.IntegrationTests
+{
+    [Collection("WebSocket Test Collection")]
+    public class WebSocketTests
+    {
+        private readonly WebSocketFixture _fixture;
+
+        public WebSocketTests(WebSocketFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public async Task Authenticated_User_Should_Echo_Message()
+        {
+            // Arrange
+            var wsUri = new Uri($"{_fixture.ServerAddress.Replace("http", "ws")}/ws/auth");
+            using var client = new ClientWebSocket();
+            client.Options.SetRequestHeader("Test-Auth", "true");
+            Console.WriteLine($"Connecting to WebSocket at: {wsUri}");
+
+            // Act
+            await client.ConnectAsync(wsUri, CancellationToken.None);
+
+            // Assert connection
+            client.State.Should().Be(WebSocketState.Open, because: "the WebSocket connection should be established successfully for authenticated users");
+
+            // Buffer and builder for receiving messages
+            var buffer = new byte[1024];
+            var receivedMessage = new StringBuilder();
+            WebSocketReceiveResult result;
+
+            // Handle initial "ready" message
+            result = await client.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
+            receivedMessage.Append(Encoding.UTF8.GetString(buffer, 0, result.Count));
+            var initialMessage = receivedMessage.ToString();
+            initialMessage.Should().Be("ready", because: "the server should send an initial 'ready' message upon connection");
+            Console.WriteLine($"Received initial message: {initialMessage}");
+            receivedMessage.Clear();
+
+            // Send a message
+            var message = "Hello WebSocket";
+            var messageBytes = Encoding.UTF8.GetBytes(message);
+            await client.SendAsync(new ArraySegment<byte>(messageBytes), WebSocketMessageType.Text, true, CancellationToken.None);
+            Console.WriteLine($"Sent message: {message}");
+
+            // Receive the echoed message
+            do
+            {
+                result = await client.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
+                receivedMessage.Append(Encoding.UTF8.GetString(buffer, 0, result.Count));
+            }
+            while (!result.EndOfMessage);
+
+            // Validate the echoed message
+            var echoedMessage = receivedMessage.ToString();
+            echoedMessage.Should().Be($"Echo: {message}", because: "the server should echo back the sent message prefixed with 'Echo:'");
+            Console.WriteLine($"Received echoed message: {echoedMessage}");
+
+            // Close the WebSocket
+            await client.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closing", CancellationToken.None);
+            client.State.Should().Be(WebSocketState.Closed, because: "the WebSocket connection should be closed gracefully");
+            Console.WriteLine("WebSocket connection closed.");
+        }
+
+        [Fact]
+        public async Task Unauthenticated_User_Should_Not_Connect()
+        {
+            // Arrange
+            var wsUri = new Uri($"{_fixture.ServerAddress.Replace("http", "ws")}/ws/auth");
+            using var clientWebSocket = new ClientWebSocket();
+            Console.WriteLine($"Attempting unauthenticated connection to WebSocket at: {wsUri}");
+
+            // Act
+            await clientWebSocket.ConnectAsync(wsUri, CancellationToken.None);
+
+            // Attempt to receive a close message from the server
+            var buffer = new byte[1024];
+            var receiveTask = clientWebSocket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
+            var result = await receiveTask;
+
+            // Assert
+            result.MessageType.Should().Be(WebSocketMessageType.Close, because: "the server should close the connection for unauthenticated users");
+            result.CloseStatus.Should().Be(WebSocketCloseStatus.PolicyViolation, because: "the server should specify policy violation for unauthenticated connections");
+            clientWebSocket.State.Should().Be(WebSocketState.CloseReceived, because: "the WebSocket connection should be closed by the server");
+            Console.WriteLine("Unauthenticated WebSocket connection was correctly refused.");
+        }
+
+        [Fact]
+        public async Task Broadcast_Message_Should_Be_Received_By_All_Connected_Clients()
+        {
+            // 1) Connect two distinct users (via query param, or you can set "Test-User" headers)
+            var wsUriClient1 = new Uri($"{_fixture.ServerAddress.Replace("http", "ws")}/ws/auth?user=client1");
+            var wsUriClient2 = new Uri($"{_fixture.ServerAddress.Replace("http", "ws")}/ws/auth?user=client2");
+
+            using var client1 = new ClientWebSocket();
+            client1.Options.SetRequestHeader("Test-Auth", "true");
+
+            using var client2 = new ClientWebSocket();
+            client2.Options.SetRequestHeader("Test-Auth", "true");
+
+            // Connect both
+            await Task.WhenAll(
+                client1.ConnectAsync(wsUriClient1, CancellationToken.None),
+                client2.ConnectAsync(wsUriClient2, CancellationToken.None)
+            );
+
+            client1.State.Should().Be(WebSocketState.Open);
+            client2.State.Should().Be(WebSocketState.Open);
+
+            // 2) Both must consume the initial "ready"
+            await ReadReadyMessage(client1, "client1");
+            await ReadReadyMessage(client2, "client2");
+
+            // 3) Broadcast a message
+            var broadcastMessage = "This is a broadcast message.";
+            await _fixture.Host.Services.GetRequiredService<IWebSocketManager>()
+                      .BroadcastAsync(broadcastMessage);
+
+            // 4) Each client reads the broadcast with a short timeout
+            var task1 = ExpectMessage(client1, $"{broadcastMessage}", "client1");
+            var task2 = ExpectMessage(client2, $"{broadcastMessage}", "client2");
+
+            await Task.WhenAll(task1, task2);
+
+            // 5) Close both clients gracefully
+            await Task.WhenAll(
+                CloseIfOpen(client1),
+                CloseIfOpen(client2)
+            );
+
+            // Final states: closed or possibly aborted
+            client1.State.Should().BeOneOf(WebSocketState.Closed, WebSocketState.Aborted);
+            client2.State.Should().BeOneOf(WebSocketState.Closed, WebSocketState.Aborted);
+        }
+
+        [Fact]
+        public async Task Send_Message_To_Specific_User_Should_Be_Received_By_Target_Client_Only()
+        {
+            // Arrange
+            var wsUri1 = new Uri($"{_fixture.ServerAddress.Replace("http", "ws")}/ws/auth?user=client1");
+            var wsUri2 = new Uri($"{_fixture.ServerAddress.Replace("http", "ws")}/ws/auth?user=client2");
+
+            using var client1 = new ClientWebSocket();
+            client1.Options.SetRequestHeader("Test-Auth", "true");
+
+            using var client2 = new ClientWebSocket();
+            client2.Options.SetRequestHeader("Test-Auth", "true");
+
+            // 1. Connect both clients
+            await Task.WhenAll(
+                client1.ConnectAsync(wsUri1, CancellationToken.None),
+                client2.ConnectAsync(wsUri2, CancellationToken.None)
+            );
+
+            client1.State.Should().Be(WebSocketState.Open);
+            client2.State.Should().Be(WebSocketState.Open);
+
+            // 2. Read the initial "ready" message from each client
+            var buffer = new byte[1024];
+
+            var result1 = await client1.ReceiveAsync(buffer, CancellationToken.None);
+            var msg1 = Encoding.UTF8.GetString(buffer, 0, result1.Count);
+            msg1.Should().Be("ready", because: "server sends a 'ready' message at connection");
+
+            var result2 = await client2.ReceiveAsync(buffer, CancellationToken.None);
+            var msg2 = Encoding.UTF8.GetString(buffer, 0, result2.Count);
+            msg2.Should().Be("ready", because: "server sends a 'ready' message at connection");
+
+            // Act
+            // 3. Send a message to client2 only
+            var targetUserId = "client2";
+            var specificMessage = "Hello Client2!";
+            await _fixture.Host.Services
+                          .GetRequiredService<IWebSocketManager>()
+                          .SendMessageAsync(targetUserId, specificMessage);
+
+            // 4. client1: we expect NO message, so we do a quick read with a short timeout
+            var buffer1 = new byte[1024];
+            using var ctsClient1 = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+            var receiveTask1 = Task.Run(async () =>
+            {
+                try
+                {
+                    var r1 = await client1.ReceiveAsync(new ArraySegment<byte>(buffer1), ctsClient1.Token);
+                    // If we got data, that's unexpected
+                    throw new Xunit.Sdk.XunitException(
+                        $"Client1 unexpectedly received: {Encoding.UTF8.GetString(buffer1, 0, r1.Count)}");
+                }
+                catch (OperationCanceledException)
+                {
+                    // good -> client1 got no message for 1s
+                }
+            });
+
+            // 5. client2: we DO expect the message
+            var buffer2 = new byte[1024];
+            using var ctsClient2 = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var receiveTask2 = Task.Run(async () =>
+            {
+                var r2 = await client2.ReceiveAsync(new ArraySegment<byte>(buffer2), ctsClient2.Token);
+                var receivedMsg = Encoding.UTF8.GetString(buffer2, 0, r2.Count);
+                receivedMsg.Should().Be($"{specificMessage}",
+                    because: "client2 should get the message intended for them");
+            });
+
+            await Task.WhenAll(receiveTask1, receiveTask2);
+
+            // 6. Cleanup - use a helper that closes if possible
+            await Task.WhenAll(
+                GracefulCloseIfOpen(client1),
+                GracefulCloseIfOpen(client2)
+            );
+
+            // 7. Assert final states
+            client1.State.Should().BeOneOf(WebSocketState.Closed, WebSocketState.Aborted);
+            client2.State.Should().BeOneOf(WebSocketState.Closed, WebSocketState.Aborted);
+        }
+
+
+        [Fact]
+        public async Task Server_Should_Handle_Multiple_Concurrent_Connections()
+        {
+            // Arrange
+            var wsUri = new Uri($"{_fixture.ServerAddress.Replace("http", "ws")}/ws/auth");
+            int clientCount = 10; // Number of concurrent clients
+            var clients = new List<ClientWebSocket>();
+            var tasks = new List<Task>();
+
+            // Act
+            // Initialize and connect multiple clients with unique user identities
+            for (int i = 0; i < clientCount; i++)
+            {
+                var client = new ClientWebSocket();
+                client.Options.SetRequestHeader("Test-Auth", "true");
+                client.Options.SetRequestHeader("Test-User", $"testuser{i + 1}"); // Unique user
+                clients.Add(client);
+                tasks.Add(client.ConnectAsync(wsUri, CancellationToken.None));
+            }
+
+            await Task.WhenAll(tasks);
+
+            // Assert all clients are connected
+            foreach (var client in clients)
+            {
+                client.State.Should().Be(WebSocketState.Open, because: "all clients should be connected successfully");
+            }
+
+            // Handle initial "ready" messages for all clients
+            var readyTasks = clients.Select(client =>
+            {
+                var buffer = new byte[1024];
+                return client.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None)
+                             .ContinueWith(t => Encoding.UTF8.GetString(buffer, 0, t.Result.Count));
+            }).ToArray();
+
+            var initialMessages = await Task.WhenAll(readyTasks);
+
+            // Assert all clients received "ready"
+            foreach (var message in initialMessages)
+            {
+                message.Should().Be("ready", because: "the server should send an initial 'ready' message upon connection");
+            }
+
+            // Send messages from all clients concurrently
+            var sendTasks = clients.Select((client, index) =>
+            {
+                var message = $"Message from client {index + 1}";
+                var messageBytes = Encoding.UTF8.GetBytes(message);
+                return client.SendAsync(new ArraySegment<byte>(messageBytes), WebSocketMessageType.Text, true, CancellationToken.None);
+            }).ToArray();
+
+            await Task.WhenAll(sendTasks);
+
+            // Receive echoed messages from all clients
+            var receiveTasks = clients.Select(client =>
+            {
+                var buffer = new byte[1024];
+                return client.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None)
+                             .ContinueWith(t => Encoding.UTF8.GetString(buffer, 0, t.Result.Count));
+            }).ToArray();
+
+            var receivedMessages = await Task.WhenAll(receiveTasks);
+
+            // Assert each client received the correct echoed message
+            for (int i = 0; i < clientCount; i++)
+            {
+                receivedMessages[i].Should().Be($"Echo: Message from client {i + 1}", because: $"client {i + 1} should receive its own echoed message");
+            }
+
+            // Cleanup
+            var closeTasks = clients.Select(client =>
+                client.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closing", CancellationToken.None)
+            ).ToArray();
+
+            await Task.WhenAll(closeTasks);
+
+            // Wait briefly to ensure handshake completion
+            await Task.Delay(500);
+
+            foreach (var client in clients)
+            {
+                client.State.Should().Be(WebSocketState.Closed, because: "all clients should be closed gracefully");
+            }
+        }
+
+
+        [Fact]
+        public async Task Server_Should_Remove_WebSocket_On_Client_Disconnect()
+        {
+            // Arrange
+            
+            var wsUri = new Uri($"{_fixture.ServerAddress.Replace("http", "ws")}/ws/auth?user=client1");
+            using var client = new ClientWebSocket();
+            client.Options.SetRequestHeader("Test-Auth", "true");
+
+            await client.ConnectAsync(wsUri, CancellationToken.None);
+            client.State.Should().Be(WebSocketState.Open, because: "client should be connected");
+
+            // Act
+            // Close the client connection
+            await client.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closing", CancellationToken.None);
+            client.State.Should().Be(WebSocketState.Closed, because: "client should have closed the connection");
+
+            // Allow some time for the server to process the disconnect
+            await Task.Delay(500);
+
+            // Assert
+            // Verify that the server no longer has the WebSocket in its dictionary
+            var userId = "client1"; // As per TestAuthHandler
+            var webSocketManager = _fixture.Host.Services.GetRequiredService<IWebSocketManager>() as AuthWebSocketManager;
+            //webSocketManager.UserSockets.Should().NotContainKey(userId, because: "the server should remove the WebSocket connection upon client disconnect");
+
+            Console.WriteLine("WebSocket connection was correctly removed from the server upon client disconnect.");
+        }
+
+        [Fact]
+        public async Task Server_Should_Handle_Malformed_Messages_Gracefully()
+        {
+            // Arrange
+            var wsUri = new Uri($"{_fixture.ServerAddress.Replace("http", "ws")}/ws/auth");
+            using var client = new ClientWebSocket();
+            client.Options.SetRequestHeader("Test-Auth", "true");
+
+            await client.ConnectAsync(wsUri, CancellationToken.None);
+            client.State.Should().Be(WebSocketState.Open, because: "client should be connected");
+
+            // Wait for the "ready" message
+            var buffer = new byte[1024];
+            var readyResult = await client.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
+            var readyMessage = Encoding.UTF8.GetString(buffer, 0, readyResult.Count);
+            readyMessage.Should().Be("ready", because: "the server should send a 'ready' message upon connection");
+
+            // Act
+            // Send a malformed message (binary data instead of text)
+            var malformedData = new byte[] { 0xFF, 0xFE, 0xFD };
+            await client.SendAsync(new ArraySegment<byte>(malformedData), WebSocketMessageType.Binary, true, CancellationToken.None);
+
+            // Attempt to receive a response
+            var receiveResult = await client.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
+
+            // Assert
+            receiveResult.MessageType.Should().Be(WebSocketMessageType.Close, because: "the server should send a close frame for malformed messages");
+            client.State.Should().Be(WebSocketState.CloseReceived, because: "the client should recognize the close frame sent by the server");
+            Console.WriteLine("Server correctly handled the malformed message by closing the connection.");
+        }
+
+        [Fact]
+        public async Task Server_Should_Reject_Too_Large_Messages_With_ForcedAbort()
+        {
+            // Arrange
+            var wsUri = new Uri($"{_fixture.ServerAddress.Replace("http", "ws")}/ws/auth");
+            using var client = new ClientWebSocket();
+            client.Options.SetRequestHeader("Test-Auth", "true");
+
+            await client.ConnectAsync(wsUri, CancellationToken.None);
+
+            // 1) Read the "ready" message
+            var buffer = new byte[1024];
+            var firstResult = await client.ReceiveAsync(buffer, CancellationToken.None);
+            var initialMsg = Encoding.UTF8.GetString(buffer, 0, firstResult.Count);
+            initialMsg.Should().Be("ready");
+
+            // 2) Send large (5 KB) message
+            var largeMessage = new string('A', 5 * 1024);
+            var largeBytes = Encoding.UTF8.GetBytes(largeMessage);
+            await client.SendAsync(new ArraySegment<byte>(largeBytes), WebSocketMessageType.Text, true, CancellationToken.None);
+
+            // 3) Try to read again; accept *any* sign of forced closure
+            bool forciblyClosed = false;
+            try
+            {
+                var secondResult = await client.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
+
+                // If we get 0 bytes or the state is no longer open, consider it forcibly closed
+                if (secondResult.Count == 0
+                    || client.State == WebSocketState.Aborted
+                    || secondResult.CloseStatus.HasValue)
+                {
+                    forciblyClosed = true;
+                }
+                else
+                {
+                    // Possibly we got some weird partial read, or a random text message
+                    // That would be unexpected 
+                }
+            }
+            catch (WebSocketException)
+            {
+                // If we catch an exception, that also indicates forced closure
+                forciblyClosed = true;
+            }
+
+            forciblyClosed.Should().BeTrue("we expect the server to forcibly close or abort on oversized messages");
+        }
+
+        [Fact]
+        public async Task Should_Not_Hang()
+        {
+            using var client = new ClientWebSocket();
+            await client.ConnectAsync(new Uri($"{_fixture.ServerAddress.Replace("http", "ws")}/ws/auth"), CancellationToken.None);
+
+            // Example: 5-second timeout for reading
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var buffer = new byte[1024];
+
+            try
+            {
+                var result = await client.ReceiveAsync(new ArraySegment<byte>(buffer), cts.Token);
+                // If the server never sends data within 5 seconds, an OperationCanceledException is thrown -> test ends.
+            }
+            catch (OperationCanceledException)
+            {
+                // 1: Throw an XunitException to indicate a test failure in xUnit
+                throw new XunitException("Timed out waiting for a message from the server.");
+            }
+        }
+
+
+
+
+        [Fact]
+        public async Task Server_Should_Shutdown_Gracefully_With_Active_Connections()
+        {
+            // Arrange
+            var wsUri = new Uri($"{_fixture.ServerAddress.Replace("http", "ws")}/ws/auth?user=client1");
+            using var client = new ClientWebSocket();
+            client.Options.SetRequestHeader("Test-Auth", "true");
+
+            Console.WriteLine($"Connecting to WebSocket at: {wsUri}");
+
+            await client.ConnectAsync(wsUri, CancellationToken.None);
+            client.State.Should().Be(WebSocketState.Open, because: "client should be connected");
+
+            Console.WriteLine("WebSocket connection established.");
+
+            // Prepare to receive close message with timeout
+            var buffer = new byte[1024];
+            var receiveTask = Task.Run(async () =>
+            {
+                try
+                {
+                    var result = await client.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
+                    Console.WriteLine($"Received message from server: {result.MessageType} with status: {result.CloseStatus}");
+                    return result;
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Exception in receiveTask: {ex.Message}");
+                    throw;
+                }
+            });
+
+            // Act
+            Console.WriteLine("Initiating server shutdown...");
+            var shutdownTask = _fixture.Host.StopAsync();
+
+            // Await both shutdown and receiveTask with a timeout
+            var allTasks = Task.WhenAll(shutdownTask, receiveTask);
+            var completedTask = await Task.WhenAny(allTasks, Task.Delay(TimeSpan.FromSeconds(60)));
+
+            if (completedTask != allTasks)
+            {
+                Console.WriteLine("Test timed out while waiting for server shutdown or WebSocket closure.");
+                Assert.True(false, "Test timed out waiting for server shutdown and WebSocket closure.");
+                return;
+            }
+
+            // Assert
+            try
+            {
+
+                WebSocketCloseStatus? closeStatus = null;
+                WebSocketMessageType msgType = WebSocketMessageType.Text;
+
+                while (closeStatus == null)
+                {
+                    var result = await client.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
+                    msgType = result.MessageType;
+                    closeStatus = result.CloseStatus;
+
+                    if (msgType == WebSocketMessageType.Text)
+                    {
+                        var msg = Encoding.UTF8.GetString(buffer, 0, result.Count);
+                        Console.WriteLine($"Received text message: {msg}");
+                        // Possibly ignore it or keep track
+                    }
+                }
+
+                Assert.Equal(WebSocketMessageType.Close, msgType);
+                Assert.Equal(WebSocketCloseStatus.NormalClosure, closeStatus);
+                Console.WriteLine("WebSocket connection closed gracefully by the server.");
+            }
+            catch (WebSocketException ex)
+            {
+                Console.WriteLine($"WebSocketException occurred: {ex.Message}");
+                Assert.True(client.State == WebSocketState.Aborted, $"WebSocket should be Aborted if handshake failed. Error: {ex.Message}");
+            }
+        }
+        [Fact]
+        public async Task Server_Should_Replace_Existing_Connection_For_Same_User()
+        {
+            // Arrange
+            var wsUri = new Uri($"{_fixture.ServerAddress.Replace("http", "ws")}/ws/auth");
+
+            using var clientSocket1 = new ClientWebSocket();
+            using var clientSocket2 = new ClientWebSocket();
+
+            clientSocket1.Options.SetRequestHeader("Test-Auth", "true");
+            clientSocket1.Options.SetRequestHeader("Test-User", "testuser");
+
+            clientSocket2.Options.SetRequestHeader("Test-Auth", "true");
+            clientSocket2.Options.SetRequestHeader("Test-User", "testuser");
+
+            // Connect clientSocket1
+            await clientSocket1.ConnectAsync(wsUri, CancellationToken.None);
+            Console.WriteLine("clientSocket1 connected.");
+
+            // Connect clientSocket2 and wait for readiness acknowledgment
+            await clientSocket2.ConnectAsync(wsUri, CancellationToken.None);
+            Console.WriteLine("clientSocket2 connected.");
+
+            // Receive readiness acknowledgment from server
+            var readinessMessage = await RetryReceiveMessage(clientSocket2, 5, TimeSpan.FromMilliseconds(500));
+            Assert.Equal("ready", readinessMessage);
+            Console.WriteLine("Received readiness acknowledgment from server.");
+
+            // Send a message from clientSocket2
+            var message = "Test message";
+            var buffer = Encoding.UTF8.GetBytes(message);
+            await clientSocket2.SendAsync(new ArraySegment<byte>(buffer), WebSocketMessageType.Text, true, CancellationToken.None);
+            Console.WriteLine("Sent message from clientSocket2.");
+
+            // Assert clientSocket2 remains open
+            Assert.Equal(WebSocketState.Open, clientSocket2.State);
+
+            // Receive echoed message on clientSocket2
+            var receivedMessage = await RetryReceiveMessage(clientSocket2, 5, TimeSpan.FromMilliseconds(500));
+            Assert.Equal($"Echo: {message}", receivedMessage);
+            Console.WriteLine("Received echoed message from server.");
+
+
+        }
+
+        // Helper method for retries
+        private async Task<string> RetryReceiveMessage(ClientWebSocket clientSocket, int maxAttempts, TimeSpan delay)
+        {
+            var buffer = new byte[1024];
+
+            for (int attempt = 1; attempt <= maxAttempts; attempt++)
+            {
+                try
+                {
+                    var result = await clientSocket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
+
+                    if (result.MessageType == WebSocketMessageType.Text)
+                    {
+                        var message = Encoding.UTF8.GetString(buffer, 0, result.Count);
+                        Console.WriteLine($"Received message: {message}");
+                        return message;
+                    }
+                }
+                catch (WebSocketException ex)
+                {
+                    // Log and retry
+                    Console.WriteLine($"Retry {attempt}/{maxAttempts} failed: {ex.Message}");
+                }
+
+                await Task.Delay(delay);
+            }
+
+            throw new TimeoutException("Failed to receive message within the allotted retries.");
+        }
+        // Helper that closes the socket if it is still open or close-received
+        private static async Task GracefulCloseIfOpen(ClientWebSocket socket)
+        {
+            if (socket.State is WebSocketState.Open or WebSocketState.CloseReceived)
+            {
+                try
+                {
+                    await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closing", CancellationToken.None);
+                }
+                catch (WebSocketException)
+                {
+                    // Already aborted or forcibly closed, ignore
+                }
+            }
+        }
+        // Helper: read the initial "ready"
+        private async Task ReadReadyMessage(ClientWebSocket client, string clientName)
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+            var buffer = new byte[1024];
+            var result = await client.ReceiveAsync(new ArraySegment<byte>(buffer), cts.Token);
+            var msg = Encoding.UTF8.GetString(buffer, 0, result.Count);
+            msg.Should().Be("ready", $"{clientName} should receive 'ready' on connect");
+        }
+        // Helper: wait for an expected message with a short timeout
+        private async Task ReceiveExpectedMessage(ClientWebSocket client, string expectedMessage, string clientName)
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var buffer = new byte[1024];
+            var result = await client.ReceiveAsync(new ArraySegment<byte>(buffer), cts.Token);
+            var msg = Encoding.UTF8.GetString(buffer, 0, result.Count);
+            msg.Should().Be(expectedMessage, $"{clientName} should receive the broadcast message");
+        }
+
+        // Graceful close if open
+        private async Task CloseIfOpen(ClientWebSocket socket)
+        {
+            if (socket.State is WebSocketState.Open or WebSocketState.CloseReceived)
+            {
+                try
+                {
+                    await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closing", CancellationToken.None);
+                }
+                catch (WebSocketException)
+                {
+                    // Already aborted or forcibly closed
+                }
+            }
+        }
+        private static async Task ExpectMessage(
+        ClientWebSocket client,
+        string expectedMessage,
+        string clientName,
+        TimeSpan? timeout = null)
+            {
+            // Because reason X: we want a short read timeout, e.g. 3 seconds by default
+            using var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromSeconds(3));
+
+            var buffer = new byte[1024];
+            try
+            {
+                var result = await client.ReceiveAsync(buffer, cts.Token);
+
+                var actualMessage = Encoding.UTF8.GetString(buffer, 0, result.Count);
+
+                actualMessage.Should().Be(expectedMessage,
+                    because: $"client {clientName} should receive the broadcast message");
+            }
+            catch (OperationCanceledException)
+            {
+                throw new Xunit.Sdk.XunitException(
+                    $"Timed out waiting for message '{expectedMessage}' on client {clientName}.");
+            }
+        }
+    }
+}

--- a/Backend/AssemblyInfo.cs
+++ b/Backend/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Backend.Tests")]

--- a/Backend/Backend.csproj
+++ b/Backend/Backend.csproj
@@ -44,7 +44,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Folder Include="Auth\" />
     <Folder Include="Domain\Interfaces\" />
+    <Folder Include="Infrastructure\Services\" />
     <Folder Include="logs\" />
 	<Folder Include="Infrastructure\Security\" />
   </ItemGroup>

--- a/Backend/Infrastructure/Interfaces/IMessageSender.cs
+++ b/Backend/Infrastructure/Interfaces/IMessageSender.cs
@@ -1,0 +1,7 @@
+﻿namespace Backend.Infrastructure.Interfaces
+{
+    public interface IMessageSender
+    {
+        Task SendMessageAsync(string userId, string message);
+    }
+}

--- a/Backend/Infrastructure/Interfaces/IWebSocketHandler.cs
+++ b/Backend/Infrastructure/Interfaces/IWebSocketHandler.cs
@@ -1,0 +1,11 @@
+﻿using System.Net.WebSockets;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace Backend.Infrastructure.Interfaces
+{
+    public interface IWebSocketHandler
+    {
+        Task HandleAsync(HttpContext context, WebSocket webSocket);
+    }
+}

--- a/Backend/Infrastructure/Interfaces/IWebSocketManager.cs
+++ b/Backend/Infrastructure/Interfaces/IWebSocketManager.cs
@@ -1,0 +1,11 @@
+﻿using System.Net.WebSockets;
+
+namespace Backend.Infrastructure.Interfaces
+{
+    public interface IWebSocketManager
+    {
+        Task HandleConnectionAsync(WebSocket webSocket, HttpContext context);
+        Task SendMessageAsync(string userId, string message);
+        Task BroadcastAsync(string message);
+    }
+}

--- a/Backend/Infrastructure/WebSockets/AuthWebSocketManager.cs
+++ b/Backend/Infrastructure/WebSockets/AuthWebSocketManager.cs
@@ -1,0 +1,357 @@
+﻿using System.Collections.Concurrent;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Backend.Infrastructure.Interfaces;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Backend.Infrastructure.WebSockets
+{
+    public record WebSocketConnection(WebSocket Socket, CancellationTokenSource Cts);
+    public class AuthWebSocketManager : IWebSocketManager, IHostedService
+    {
+        private readonly ConcurrentDictionary<string, SemaphoreSlim> _userLocks = new();
+        private readonly ConcurrentDictionary<string, WebSocketConnection> _userSockets = new();
+        private readonly ILogger<AuthWebSocketManager> _logger;
+        private const int MAX_MESSAGE_SIZE_BYTES = 4 * 1024; // 4 KB, adjust as needed. Max WebSocket message size
+
+        public AuthWebSocketManager(ILogger<AuthWebSocketManager> logger)
+        {
+            _logger = logger;
+        }
+
+        // IHostedService implementation
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            // No initialization required for this manager
+            _logger.LogInformation("AuthWebSocketManager started.");
+            return Task.CompletedTask;
+        }
+
+        public async Task StopAsync(CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("StopAsync invoked for AuthWebSocketManager.");
+            _logger.LogInformation($"Number of active WebSocket connections before closure: {_userSockets.Count}");
+
+            var closeTasks = _userSockets.Values.Select(async conn =>
+            {
+                var socket = conn.Socket;
+                try
+                {
+                    // Cancel any running ReceiveAsync loops
+                    conn.Cts.Cancel();
+
+                    if (socket.State == WebSocketState.Open || socket.State == WebSocketState.CloseReceived)
+                    {
+                        using var closeCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+                        try
+                        {
+                            await socket.CloseAsync(
+                                WebSocketCloseStatus.NormalClosure,
+                                "Server shutting down",
+                                closeCts.Token
+                            );
+                            _logger.LogInformation("WebSocket connection closed gracefully.");
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogWarning($"Closing socket for shutdown failed: {ex.Message}. Aborting.");
+                            socket.Abort();
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError($"Error closing WebSocket: {ex.Message}");
+                }
+            });
+
+            await Task.WhenAll(closeTasks);
+
+            // Remove them all from the dictionary
+            var users = _userSockets.Keys.ToList();
+            foreach (var userId in users)
+            {
+                if (_userSockets.TryRemove(userId, out _))
+                {
+                    _logger.LogInformation($"Removed WebSocket for user {userId} during StopAsync.");
+                }
+            }
+
+            // Optional small delay
+            await Task.Delay(1000, cancellationToken);
+
+            _logger.LogInformation("All active WebSocket connections have been closed.");
+            _logger.LogInformation($"Number of WebSocket connections after closure: {_userSockets.Count}");
+        }
+
+        // The main entrypoint for each WebSocket connection
+        public async Task HandleConnectionAsync(WebSocket webSocket, HttpContext context)
+        {
+            string userId = null;
+            SemaphoreSlim userLock = null;
+
+            try
+            {
+                _logger.LogInformation("HandleConnectionAsync started.");
+
+                // 1. Check if the user is authenticated
+                if (!context.User.Identity.IsAuthenticated)
+                {
+                    _logger.LogWarning("Unauthenticated user. Closing immediately.");
+                    await webSocket.CloseAsync(WebSocketCloseStatus.PolicyViolation, "Not authenticated", CancellationToken.None);
+                    return;
+                }
+
+                userId = context.User.FindFirst("sub")?.Value;
+                if (string.IsNullOrEmpty(userId))
+                {
+                    _logger.LogWarning("Missing 'sub' claim. Closing socket.");
+                    await webSocket.CloseAsync(WebSocketCloseStatus.PolicyViolation, "User ID not found", CancellationToken.None);
+                    return;
+                }
+
+                // 2. Acquire a lock for this user
+                userLock = _userLocks.GetOrAdd(userId, _ => new SemaphoreSlim(1, 1));
+                await userLock.WaitAsync();
+
+                // 3. If there's an existing connection, replace it
+                try
+                {
+                    if (_userSockets.TryGetValue(userId, out var oldConn))
+                    {
+                        _logger.LogWarning($"Connection for {userId} already exists, replacing.");
+
+                        // Remove old from dictionary so it won't remove the new one in its finally block
+                        _userSockets.TryRemove(userId, out _);
+
+                        // Cancel the old connection's read loop
+                        oldConn.Cts.Cancel();
+
+                        // Gracefully close old socket
+                        if (oldConn.Socket.State == WebSocketState.Open)
+                        {
+                            try
+                            {
+                                await oldConn.Socket.CloseAsync(
+                                    WebSocketCloseStatus.NormalClosure,
+                                    "Replaced by new connection",
+                                    CancellationToken.None
+                                );
+                            }
+                            catch (Exception ex)
+                            {
+                                _logger.LogWarning($"Old socket CloseAsync failed: {ex.Message}. Aborting old socket.");
+                                oldConn.Socket.Abort();
+                            }
+                        }
+                    }
+
+                    // 4. Now add the new connection
+                    var cts = new CancellationTokenSource();
+                    var newConn = new WebSocketConnection(webSocket, cts);
+
+                    if (!_userSockets.TryAdd(userId, newConn))
+                    {
+                        _logger.LogWarning($"Failed to add new WebSocket for user {userId}.");
+                        await webSocket.CloseAsync(WebSocketCloseStatus.InternalServerError, "Could not add connection", CancellationToken.None);
+                        return;
+                    }
+
+                    _logger.LogInformation($"WebSocket connection established for user {userId}.");
+                    // Send readiness acknowledgment
+                    await SendMessageAsync(userId, "ready");
+                }
+                finally
+                {
+                    userLock.Release();
+                }
+
+                // 5. Start reading messages until canceled or socket closes
+                await ReadLoopAsync(userId, webSocket);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"HandleConnectionAsync crashed for user {userId}: {ex.Message}");
+            }
+            finally
+            {
+                _logger.LogDebug($"Cleaning up WebSocket for user {userId}...");
+
+                // 6. Cleanup only if we still own this connection
+                if (!string.IsNullOrEmpty(userId))
+                {
+                    await userLock.WaitAsync();
+                    try
+                    {
+                        if (_userSockets.TryGetValue(userId, out var currentConn) && currentConn.Socket == webSocket)
+                        {
+                            _userSockets.TryRemove(userId, out _);
+                            _logger.LogInformation($"Removed WebSocket for user {userId} in final cleanup.");
+
+                            // Try graceful close if it's still open
+                            if (webSocket.State == WebSocketState.Open || webSocket.State == WebSocketState.CloseReceived)
+                            {
+                                try
+                                {
+                                    _logger.LogInformation($"Closing WebSocket for {userId} gracefully in final cleanup.");
+                                    await webSocket.CloseAsync(
+                                        WebSocketCloseStatus.NormalClosure,
+                                        "Closing from final cleanup",
+                                        CancellationToken.None
+                                    );
+                                }
+                                catch (Exception ex)
+                                {
+                                    _logger.LogError($"Error during final CloseAsync: {ex.Message}");
+                                }
+                            }
+                        }
+
+                        // Remove the userLock if done
+                        _userLocks.TryRemove(userId, out _);
+                    }
+                    finally
+                    {
+                        userLock.Release();
+                    }
+                }
+                _logger.LogDebug($"Cleanup done for user {userId}.");
+            }
+        }
+
+        //  Read loop that ends if the socket closes or if we canceled from replacement
+        private async Task ReadLoopAsync(string userId, WebSocket socket)
+        {
+            // Access the CancellationTokenSource we stored
+            if (!_userSockets.TryGetValue(userId, out var conn))
+            {
+                return; // If not found, the socket was replaced or removed
+            }
+
+            var cts = conn.Cts;
+            var token = cts.Token;
+            var buffer = new byte[1024];
+
+            // We'll accumulate chunks in a MemoryStream for each full message
+            using var ms = new MemoryStream();
+
+            try
+            {
+
+                while (socket.State == WebSocketState.Open && !token.IsCancellationRequested)
+                {
+                    WebSocketReceiveResult result = null;
+                    try
+                    {
+                        // Wait for data 
+                        result = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), token);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        _logger.LogInformation($"Read canceled for user {userId} (replacement or shutdown).");
+                        break;
+                    }
+                    catch (WebSocketException ex)
+                    {
+                        _logger.LogError($"WebSocketException for user {userId}: {ex.Message}");
+                        break;
+                    }
+
+                    // Check if client closed
+                    if (result.CloseStatus.HasValue)
+                    {
+                        _logger.LogInformation($"Socket for {userId} closed with status {result.CloseStatus}.");
+                        break;
+                    }
+
+
+                    // If it's text, accumulate in memory
+                    if (result.MessageType == WebSocketMessageType.Text)
+                    {
+                        // Add incoming chunk
+                        ms.Write(buffer, 0, result.Count);
+
+                        // Check if this chunk made the message exceed max size
+                        if (ms.Length > MAX_MESSAGE_SIZE_BYTES)
+                        {
+                            _logger.LogWarning($"User {userId} sent too large message. Closing.");
+                            await socket.CloseAsync(WebSocketCloseStatus.MessageTooBig,
+                                "Message too big", token);
+                            break;
+                        }
+
+                        // If this is the end of the message, process
+                        if (result.EndOfMessage)
+                        {
+                            var message = Encoding.UTF8.GetString(ms.ToArray());
+                            ms.SetLength(0); // reset stream for next message
+
+                            _logger.LogInformation($"Received message from {userId}: {message}");
+
+                            // Echo back
+                            await SendMessageAsync(userId, $"Echo: {message}");
+                        }
+                    }
+                    else
+                    {
+                        // We only support text messages
+                        _logger.LogWarning($"User {userId} sent non-text message. Closing.");
+                        await socket.CloseAsync(WebSocketCloseStatus.InvalidMessageType,
+                            "Only text supported", token);
+                        break;
+                    }
+                }
+            }
+            finally
+            {
+                _logger.LogDebug($"Read loop ended for user {userId}. Socket state: {socket.State}");
+            }
+        }
+
+        // Send message to the currently stored socket (if open)
+        public async Task SendMessageAsync(string userId, string message)
+        {
+            if (_userSockets.TryGetValue(userId, out var conn) &&
+                conn.Socket.State == WebSocketState.Open)
+            {
+                var bytes = Encoding.UTF8.GetBytes(message);
+                try
+                {
+                    _logger.LogInformation($"Sending to {userId}: {message}");
+                    await conn.Socket.SendAsync(
+                        new ArraySegment<byte>(bytes),
+                        WebSocketMessageType.Text,
+                        true,
+                        CancellationToken.None
+                    );
+                }
+                catch (WebSocketException ex)
+                {
+                    _logger.LogError($"Failed sending to user {userId}: {ex.Message}");
+                }
+            }
+            else
+            {
+                _logger.LogWarning($"Cannot send to {userId} - socket not open or not found.");
+            }
+        }
+
+        // Send a broadcast to all open connections
+        public async Task BroadcastAsync(string message)
+        {
+            var bytes = Encoding.UTF8.GetBytes(message);
+            var segment = new ArraySegment<byte>(bytes);
+
+            var tasks = _userSockets.Values
+                .Where(conn => conn.Socket.State == WebSocketState.Open)
+                .Select(conn => conn.Socket.SendAsync(segment, WebSocketMessageType.Text, true, CancellationToken.None));
+
+            await Task.WhenAll(tasks);
+        }
+
+    }
+}

--- a/Backend/Infrastructure/WebSockets/WebSocketHandler.cs
+++ b/Backend/Infrastructure/WebSockets/WebSocketHandler.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Net.WebSockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Backend.Infrastructure.Interfaces;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Backend.Infrastructure.WebSockets
+{
+    public class WebSocketHandler : IWebSocketHandler
+    {
+        private readonly ILogger<WebSocketHandler> _logger;
+
+        public WebSocketHandler(ILogger<WebSocketHandler> logger)
+        {
+            _logger = logger;
+        }
+
+        public async Task HandleAsync(HttpContext context, WebSocket webSocket)
+        {
+            var buffer = new byte[1024 * 4];
+            _logger.LogInformation("WebSocket connection established.");
+
+            while (webSocket.State == WebSocketState.Open)
+            {
+                try
+                {
+                    var result = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
+
+                    if (result.MessageType == WebSocketMessageType.Close)
+                    {
+                        _logger.LogInformation("WebSocket connection closing.");
+                        await webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closing", CancellationToken.None);
+                    }
+                    else if (result.MessageType == WebSocketMessageType.Text)
+                    {
+                        var message = Encoding.UTF8.GetString(buffer, 0, result.Count);
+                        _logger.LogInformation($"Received message: {message}");
+
+                        if (message.Equals("logout", StringComparison.OrdinalIgnoreCase))
+                        {
+                            var response = Encoding.UTF8.GetBytes("LOGOUT");
+                            await webSocket.SendAsync(new ArraySegment<byte>(response), WebSocketMessageType.Text, true, CancellationToken.None);
+                            _logger.LogInformation("Sent LOGOUT response.");
+                        }
+
+                        // Handle other messages as needed
+                    }
+                    // Handle other message types if necessary
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error occurred while handling WebSocket connection.");
+                    break;
+                }
+            }
+
+            _logger.LogInformation("WebSocket connection closed.");
+        }
+    }
+}

--- a/Backend/Presentation/Controllers/LoginController.cs
+++ b/Backend/Presentation/Controllers/LoginController.cs
@@ -2,6 +2,7 @@
 using Backend.Application.Interfaces.RecaptchaService;
 using Backend.Application.Interfaces.UserServices;
 using Backend.Infrastructure.Helpers;
+using Backend.Infrastructure.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
@@ -13,6 +14,7 @@ namespace Backend.Presentation.Controllers
     public class AuthController : ControllerBase
     {
         private readonly IUserServices _userServices;
+        private readonly IWebSocketManager _webSocketManager;
         private readonly IUserTokenService _userTokenService;
         private readonly IUserAuthenticationService _userAuthenticationService;
         private readonly ILogger<RegistrationController> _logger;
@@ -20,9 +22,10 @@ namespace Backend.Presentation.Controllers
         private readonly IUserManagementService _userManagementService;
         private readonly LogHelper _logHelper;
 
-        public AuthController(IUserServices userServices, IUserTokenService userTokenService, IUserAuthenticationService userAuthenticationService, ILogger<RegistrationController> logger, IRecaptchaService recaptchaService, IUserManagementService userManagementService, LogHelper logHelper)
+        public AuthController(IUserServices userServices, IWebSocketManager webSocketManager, IUserTokenService userTokenService, IUserAuthenticationService userAuthenticationService, ILogger<RegistrationController> logger, IRecaptchaService recaptchaService, IUserManagementService userManagementService, LogHelper logHelper)
         {
             _userServices = userServices;
+            _webSocketManager = webSocketManager;
             _userTokenService = userTokenService;
             _userAuthenticationService = userAuthenticationService;
             _logger = logger;
@@ -98,6 +101,20 @@ namespace Backend.Presentation.Controllers
             return Unauthorized(new AuthStatusDto { Authenticated = false });
         }
 
+        [HttpPost("logout")]
+        public async Task<IActionResult> Logout()
+        {
+            // Perform logout logic, such as clearing cookies or tokens
+
+            // Notify the user via WebSocket if necessary
+            var userId = User.FindFirst("sub")?.Value;
+            if (!string.IsNullOrEmpty(userId))
+            {
+                //await _webSocketManager.SendMessageAsync(userId, "LOGOUT");
+            }
+
+            return Ok(new { message = "Logged out successfully." });
+        }
     }
 
 }


### PR DESCRIPTION
    Core Implementation
        Develop AuthWebSocketManager from the ground up, enforcing a single connection per authenticated user.
        Use _userLocks and _userSockets to safely manage concurrency and replace existing connections if the same user reconnects.
        Echo incoming text messages with 'Echo'  prefix.
        Discard non-text frames and close oversized (> 4 KB) messages with MessageTooBig.

    Testing
        Add integration tests validating authenticated/unauthenticated behavior, broadcasting, targeted user messages, message size limits, and more.
        Ensure test coverage includes concurrency scenarios and connection replacements.

    Documentation
        Provide a detailed README.md explaining setup, configuration, usage, and testing instructions for AuthWebSocketManager.

This commit delivers a robust WebSocket solution with thorough test coverage, facilitating reliable real-time communication for authenticated users.