### PR TITLE
Fixed so that we no longer assume that the token that hits the refres…

### DIFF
--- a/Backend.Tests/IntegrationTests/Services/AuthService/AuthServiceIntegrationTestsRefreshToken.cs
+++ b/Backend.Tests/IntegrationTests/Services/AuthService/AuthServiceIntegrationTestsRefreshToken.cs
@@ -134,7 +134,7 @@ namespace Backend.Tests.IntegrationTests.Services.AuthService
 
             // Assert: Verify that refresh fails due to invalid access token.
             Assert.False(refreshResult.Success, "Refresh token operation should fail with an invalid access token.");
-            Assert.Contains("invalid or expired", refreshResult.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Invalid access token. Please log in again.", refreshResult.Message, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/Backend/Application/Interfaces/JWT/IJwtService.cs
+++ b/Backend/Application/Interfaces/JWT/IJwtService.cs
@@ -8,5 +8,6 @@ namespace Backend.Application.Interfaces.JWT
         ClaimsPrincipal? ValidateToken(string token);
         Task<LoginResultDto> GenerateJWTTokenAsync(Guid persoid, string email, bool rotateToken, ClaimsPrincipal? user = null);
         Task<bool> BlacklistJwtTokenAsync(string token);
+        ClaimsPrincipal? DecodeExpiredToken(string token);
     }
 }

--- a/Backend/Application/Services/AuthService/AuthService .cs
+++ b/Backend/Application/Services/AuthService/AuthService .cs
@@ -114,10 +114,10 @@ namespace Backend.Application.Services.AuthService
         public async Task<LoginResultDto> RefreshTokenAsync(Guid persoid, string refreshToken, string accessToken, ClaimsPrincipal? user = null)
         {
             // Step 0: Validate the existing access token before proceeding
-            var validatedPrincipal = _jwtService.ValidateToken(accessToken);
+            var validatedPrincipal = _jwtService.DecodeExpiredToken(accessToken);
             if (validatedPrincipal == null)
             {
-                return new LoginResultDto { Success = false, Message = "Invalid or expired access token. Please log in again." };
+                return new LoginResultDto { Success = false, Message = "Invalid access token. Please log in again." };
             }
 
             // Step 1

--- a/Backend/Infrastructure/Implementations/JwtService.cs
+++ b/Backend/Infrastructure/Implementations/JwtService.cs
@@ -202,5 +202,32 @@ namespace Backend.Infrastructure.Implementations
                 return null;
             }
         }
+        public ClaimsPrincipal? DecodeExpiredToken(string token)
+        {
+            var tokenHandler = new JwtSecurityTokenHandler();
+            try
+            {
+                var validationParameters = new TokenValidationParameters
+                {
+                    ValidateIssuerSigningKey = true,
+                    IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_jwtSettings.SecretKey)),
+                    ValidateIssuer = true,
+                    ValidIssuer = _jwtSettings.Issuer,
+                    ValidateAudience = true,
+                    ValidAudience = _jwtSettings.Audience,
+                    ValidateLifetime = false, // We do NOT validate lifetime here, we just want to decode the token
+                    ClockSkew = TimeSpan.Zero
+                };
+
+                // This will decode the token even if it's expired.
+                var principal = tokenHandler.ValidateToken(token, validationParameters, out var validatedToken);
+                return principal;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error decoding expired token.");
+                return null;
+            }
+        }
     }
 }


### PR DESCRIPTION
…h API has a valid lifetime, since it doesnt, its expired. We just decode it and see if its a valid accesstoken. Added this method to help:public ClaimsPrincipal? DecodeExpiredToken(string token). Adjusted the AuthService, now calls this method instead of the ValidateToken directly.