### PR TITLE
feat(auth): add dedicated SessionId for unique user sessions

### DIFF
--- a/Backend.Tests/UnitTests/Services/CookieService/CookieServiceTests.cs
+++ b/Backend.Tests/UnitTests/Services/CookieService/CookieServiceTests.cs
@@ -5,6 +5,7 @@ using Backend.Common.Utilities;
 using Microsoft.Extensions.Configuration;
 using Moq;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection;
 
 namespace Backend.Tests.UnitTests.Services.CookieService
 {
@@ -30,33 +31,45 @@ namespace Backend.Tests.UnitTests.Services.CookieService
             var cookieService = new Backend.Infrastructure.Services.CookieService.CookieService(mockEnv.Object, httpContextAccessor, jwtSettings);
             string accessToken = "test-access-token";
             string refreshToken = "test-refresh-token";
+            string sessionId = "test-session-id";
 
             // Act: Call the method using the mocked HttpResponse (set up in UnitTestBase).
-            cookieService.SetAuthCookies(MockHttpContext.Object.Response, accessToken, refreshToken);
+            cookieService.SetAuthCookies(MockHttpContext.Object.Response, accessToken, refreshToken, sessionId);
 
             // Assert: Verify cookies are set in our CookiesContainer.
             Assert.True(CookiesContainer.ContainsKey("AccessToken"), "AccessToken cookie should be set.");
             Assert.True(CookiesContainer.ContainsKey("RefreshToken"), "RefreshToken cookie should be set.");
+            Assert.True(CookiesContainer.ContainsKey("SessionId"), "SessionId cookie should be set.");
 
             var accessCookie = CookiesContainer["AccessToken"];
             var refreshCookie = CookiesContainer["RefreshToken"];
+            var sessionCookie = CookiesContainer["SessionId"];
 
             Assert.Equal(accessToken, accessCookie.Value);
             Assert.Equal(refreshToken, refreshCookie.Value);
+            Assert.Equal(sessionId, sessionCookie.Value);
 
             // Verify cookie options.
             Assert.True(accessCookie.Options.HttpOnly, "AccessToken should be HttpOnly.");
             Assert.True(refreshCookie.Options.HttpOnly, "RefreshToken should be HttpOnly.");
+            Assert.True(sessionCookie.Options.HttpOnly, "SessionId should be HttpOnly.");
+
             Assert.True(accessCookie.Options.Secure, "AccessToken should be Secure.");
             Assert.True(refreshCookie.Options.Secure, "RefreshToken should be Secure.");
+            Assert.True(sessionCookie.Options.Secure, "SessionId should be Secure.");
+
             Assert.Equal(SameSiteMode.Lax, accessCookie.Options.SameSite);
             Assert.Equal(SameSiteMode.Lax, refreshCookie.Options.SameSite);
+            Assert.Equal(SameSiteMode.Lax, sessionCookie.Options.SameSite);
 
             // Verify that expiration is correctly set (greater than now).
             Assert.NotNull(accessCookie.Options.Expires);
             Assert.NotNull(refreshCookie.Options.Expires);
+            Assert.NotNull(sessionCookie.Options.Expires);
+
             Assert.True(accessCookie.Options.Expires > DateTime.UtcNow, "AccessToken cookie expiration should be in the future.");
             Assert.True(refreshCookie.Options.Expires > DateTime.UtcNow, "RefreshToken cookie expiration should be in the future.");
+            Assert.True(sessionCookie.Options.Expires > DateTime.UtcNow, "SessionId cookie expiration should be in the future.");
         }
     }
 }

--- a/Backend/Application/DTO/LoginResultDto.cs
+++ b/Backend/Application/DTO/LoginResultDto.cs
@@ -7,5 +7,6 @@
         public string UserName { get; set; }
         public string AccessToken { get; set; }
         public string ?RefreshToken { get; set; }
+        public string SessionId { get; set; }
     }
 }

--- a/Backend/Application/Interfaces/AuthService/IAuthService.cs
+++ b/Backend/Application/Interfaces/AuthService/IAuthService.cs
@@ -6,7 +6,7 @@ namespace Backend.Application.Interfaces.AuthService
     public interface IAuthService
     {
         Task<LoginResultDto> LoginAsync(UserLoginDto userLoginDto, string ipAddress, string deviceId, string userAgent);
-        Task LogoutAsync(ClaimsPrincipal user, string accessToken, string refreshTokenm, bool logoutAll);
-        Task<LoginResultDto> RefreshTokenAsync(string refreshToken, string userAgent, string deviceId, ClaimsPrincipal? user = null);
+        Task LogoutAsync(ClaimsPrincipal user, string accessToken, string refreshToken, string sessionId, bool logoutAll);
+        Task<LoginResultDto> RefreshTokenAsync(string refreshToken, string sessionId, string userAgent, string deviceId, ClaimsPrincipal? user = null);
     }
 }

--- a/Backend/Application/Interfaces/Cookies/ICookieService.cs
+++ b/Backend/Application/Interfaces/Cookies/ICookieService.cs
@@ -4,6 +4,8 @@ namespace Backend.Application.Interfaces.Cookies
 {
     public interface ICookieService
     {
-        void SetAuthCookies(HttpResponse response, string accessToken, string refreshToken);
+        void SetAuthCookies(HttpResponse response, string accessToken, string refreshToken, string sessionId);
+        public string? GetCookieValue(HttpRequest request, string cookieName);
+        public void DeleteCookie(HttpResponse response, string cookieName);
     }
 }

--- a/Backend/Application/Mappers/RefreshTokenMapper.cs
+++ b/Backend/Application/Mappers/RefreshTokenMapper.cs
@@ -16,6 +16,7 @@ namespace Backend.Application.Mappers
             return new JwtRefreshTokenModel
             {
                 Persoid = entity.Persoid,
+                SessionId = entity.SessionId,
                 RefreshToken = entity.RefreshToken,
                 AccessTokenJti = entity.AccessTokenJti,
                 RefreshTokenExpiryDate = entity.RefreshTokenExpiryDate,
@@ -33,6 +34,7 @@ namespace Backend.Application.Mappers
             return new RefreshJwtTokenEntity
             {
                 Persoid = model.Persoid,
+                SessionId = model.SessionId,
                 RefreshToken = model.RefreshToken,
                 AccessTokenJti = model.AccessTokenJti,
                 RefreshTokenExpiryDate = model.RefreshTokenExpiryDate,

--- a/Backend/Application/Models/JwtAuthenticationTokens.cs
+++ b/Backend/Application/Models/JwtAuthenticationTokens.cs
@@ -4,6 +4,7 @@
     {
         public string AccessToken { get; set; }
         public string RefreshToken { get; set; }
+        public string SessionId { get; set; }
         public string UserAgent { get; set; }
         public string DeviceId { get; set; }
     }

--- a/Backend/Application/Models/JwtRefreshTokenModel.cs
+++ b/Backend/Application/Models/JwtRefreshTokenModel.cs
@@ -3,6 +3,7 @@
     public class JwtRefreshTokenModel
     {
         public Guid Persoid { get; set; }
+        public string SessionId { get; set; }
         public string RefreshToken { get; set; }
         public string AccessTokenJti { get; set; }
         public DateTime RefreshTokenExpiryDate { get; set; }

--- a/Backend/Common/Utilities/RequestMetadataHelper.cs
+++ b/Backend/Common/Utilities/RequestMetadataHelper.cs
@@ -18,11 +18,12 @@
             return (ipAddress, userAgent, deviceId);
         }
 
-        public static (string AccessToken, string RefreshToken) ExtractTokensFromCookies(HttpContext context)
+        public static (string AccessToken, string RefreshToken, string SessionId) ExtractTokensFromCookies(HttpContext context)
         {
             var accessToken = context.Request.Cookies["AccessToken"];
             var refreshToken = context.Request.Cookies["RefreshToken"];
-            return (accessToken, refreshToken);
+            var sessionId = context.Request.Cookies["SessionId"];
+            return (accessToken, refreshToken, sessionId);
         }
     }
 }

--- a/Backend/Infrastructure/Data/Sql/Interfaces/IRefreshTokenSqlExecutor.cs
+++ b/Backend/Infrastructure/Data/Sql/Interfaces/IRefreshTokenSqlExecutor.cs
@@ -8,8 +8,7 @@ namespace Backend.Infrastructure.Data.Sql.Interfaces
         Task<IEnumerable<RefreshJwtTokenEntity>> GetRefreshTokensAsync(
                     Guid? persoid = null,
                     string refreshToken = null,
-                    string deviceId = null,
-                    string userAgent = null);
+                    string sessionId = null);
         Task<bool> AddBlacklistedTokenAsync(string jti, DateTime expiration);
         Task<bool> IsTokenBlacklistedAsync(string jti);
         Task<bool> UpdateRefreshTokenExpiryAsync(Guid persoid, DateTime newExpiry);

--- a/Backend/Infrastructure/Data/SqlCode/MariaDB/CreateTables.sql
+++ b/Backend/Infrastructure/Data/SqlCode/MariaDB/CreateTables.sql
@@ -134,6 +134,7 @@ CREATE TABLE IF NOT EXISTS PasswordResetTokens (
 CREATE TABLE RefreshTokens (
     ID INT AUTO_INCREMENT PRIMARY KEY,
     Persoid CHAR(36) NOT NULL,
+    SessionId CHAR(36) NOT NULL,
     RefreshToken VARCHAR(255) NOT NULL,
     AccessTokenJti VARCHAR(50) NOT NULL,
     RefreshTokenExpiryDate  DATETIME NOT NULL,
@@ -144,7 +145,7 @@ CREATE TABLE RefreshTokens (
     CreatedTime DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     INDEX IDX_RefreshToken (RefreshToken),
     INDEX IDX_Persoid (Persoid),
-    UNIQUE (Persoid, DeviceId, UserAgent)
+    UNIQUE (Persoid, SessionId)
 );
 
 CREATE TABLE BlacklistedTokens (

--- a/Backend/Infrastructure/Entities/RefreshJwtTokenEntity.cs
+++ b/Backend/Infrastructure/Entities/RefreshJwtTokenEntity.cs
@@ -2,8 +2,8 @@
 {
     public class RefreshJwtTokenEntity
     {
-        public int Id { get; set; } // Primary key, auto-increment
         public Guid Persoid { get; set; }
+        public string SessionId { get; set; } = string.Empty;
         public string RefreshToken { get; set; } = string.Empty;
         public string AccessTokenJti { get; set; } = string.Empty;
         public DateTime RefreshTokenExpiryDate { get; set; }


### PR DESCRIPTION
- Generate a unique SessionId (GUID as string) in the generateJwtToken routine.
- Store SessionId in the RefreshTokens table as VARCHAR(36) to uniquely identify each login session.
- Update related models and cookie handling to include the SessionId.
- Modify GetRefreshTokensAsync to accept an optional SessionId parameter (in addition to Persoid and RefreshToken), replacing the previous composite key based on Persoid, DeviceId, and UserAgent.