### PR TITLE
feat(auth): externalize scanner settings, enable token deletion, upda…

### DIFF
--- a/Backend/Application/Configuration/ExpiredTokenScannerSettings.cs
+++ b/Backend/Application/Configuration/ExpiredTokenScannerSettings.cs
@@ -1,0 +1,7 @@
+﻿namespace Backend.Application.Configuration
+{
+    public class ExpiredTokenScannerSettings
+    {
+        public int ScanIntervalMinutes { get; set; }
+    }
+}

--- a/Backend/ExpiredTokenScannerSettings.json
+++ b/Backend/ExpiredTokenScannerSettings.json
@@ -1,0 +1,3 @@
+﻿{
+    "ScanIntervalMinutes": 1
+}

--- a/Backend/appsettings.json
+++ b/Backend/appsettings.json
@@ -13,7 +13,7 @@
       {
         "Name": "File",
         "Args": {
-          "path": "logs/app-log.txt", // Relative path for logs
+          "path": "logs/app-log.txt",
           "rollingInterval": "Day"
         }
       }
@@ -22,6 +22,10 @@
     "Properties": {
       "Application": "YourApplicationName"
     }
+  },
+  "JwtSettings": {
+    "ExpiryMinutes": 15,
+    "RefreshTokenExpiryDays": 30
   },
   "AppSettings": {
     "BaseUrl": "https://ebudget.se"
@@ -37,8 +41,8 @@
     "DailyLimit": 3
   },
   "Redis": {
-    "ConnectionString": "localhost:6379", 
-    "InstanceName": "eBudget:" 
+    "ConnectionString": "localhost:6379",
+    "InstanceName": "eBudget:"
   },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
…te access token lifetime, adjust JWT expiry config

- Externalized ExpiredTokenScanner settings into a standalone configuration file for runtime adjustments.
- Reintroduced deletion of obsolete refresh tokens upon expiration to ensure proper cleanup.
- Increased access token lifetime from 3 minutes (testing) to 15 minutes for production readiness.
- Adjusted JWT settings to read Issuer, Audience, and SecretKey from environment variables while binding ExpiryMinutes and RefreshTokenExpiryDays from external configuration.