### PR TITLE
feat(websocket): add active connection logging

### DIFF
--- a/Backend/Infrastructure/WebSockets/WebSocketManager.cs
+++ b/Backend/Infrastructure/WebSockets/WebSocketManager.cs
@@ -168,6 +168,7 @@ namespace Backend.Infrastructure.WebSockets
                     _connections.TryAdd(key.ToString(), webSocket);
 
                     _logger.LogInformation($"WebSocket connection established for user {userId} session {key.SessionId}.");
+                    LogActiveConnections();
                     await SendMessageAsync(key, "ready");
                 }
                 finally
@@ -214,6 +215,8 @@ namespace Backend.Infrastructure.WebSockets
                     }
                 }
                 _logger.LogDebug($"Cleanup complete for user {userId} session {key?.SessionId}.");
+                _logger.LogInformation($"WebSocket disonnect for user {userId} session {key.SessionId}.");
+                LogActiveConnections();
             }
         }
 
@@ -380,6 +383,17 @@ namespace Backend.Infrastructure.WebSockets
                     _userSockets.TryRemove(key, out _);
                 }
             }
+        }
+        private void LogActiveConnections()
+        {
+            // Log the total number of unique connections (by composite key).
+            _logger.LogInformation("Active unique WebSocket connections: {UniqueCount}", _userSockets.Count);
+
+            // Group connections by user and log counts per user.
+            var groupedConnections = _userSockets
+                .GroupBy(kvp => kvp.Key.UserId)
+                .ToDictionary(g => g.Key, g => g.Count());
+            _logger.LogInformation("Active connections grouped by user: {@GroupedConnections}", groupedConnections);
         }
     }
 }


### PR DESCRIPTION
- Created a helper method LogActiveConnections to log:
  - The total number of active unique connections (based on composite key: userID + sessionID)
  - A breakdown of active connections grouped by user
- Called LogActiveConnections after establishing a new connection (login) and during cleanup (logout)
- Enhances observability and monitoring of concurrent WebSocket connections per user