### PR TITLE
Refactor: Use separate setters for display flags in step validation

### DIFF
--- a/Frontend/src/components/organisms/overlays/wizard/SetupWizard.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/SetupWizard.tsx
@@ -31,6 +31,9 @@ import { handleStepValidation  } from "@components/organisms/overlays/wizard/val
 // hooks
 import useSaveWizardStep from "@hooks/wizard/useSaveWizardStep";
 import useWizardInit from "@hooks/wizard/useWizardInit";
+//local display state
+import useBudgetInfoDisplayFlags from "@hooks/wizard/flagHooks/useBudgetInfoDisplayFlags";
+
 
 // Step configuration for icons & labels
 const steps = [
@@ -95,27 +98,17 @@ const SetupWizard: React.FC<SetupWizardProps> = ({ onClose }) => {
     //4: stepConfirmationRef,
   };
 
+  // State for local state
+  const { flags, setShowSideIncome, setShowHouseholdMembers } = useBudgetInfoDisplayFlags();
 
 
-  // State for showing side income and household members
-  const setShowSideIncome = (value: boolean) => {
-    setValues(prev => {
-      return { ...prev, showSideIncome: value };
-    });
-  };
-  const setShowHouseholdMembers = (value: boolean) => {
-    setValues(prev => {
-      return { ...prev, showHouseholdMembers: value };
-    });
-  };
-
-  const [values, setValues] = useState<FormValues>({ showSideIncome: false, showHouseholdMembers: false });
   
   // 6. Next / Previous Step Logic
   const nextStep = async () => {
     setTransitionLoading(true);
     // Validate step
-    const isStepValid = await handleStepValidation(step, stepRefs, setValues);
+    const isStepValid = await handleStepValidation(step, stepRefs, setShowSideIncome, setShowHouseholdMembers);
+    // If step is not valid, show shake animation
     if (!isStepValid) {
       setTransitionLoading(false);
       return;
@@ -270,9 +263,9 @@ console.log("Debug Mode:", isDebugMode);
                           initialData={wizardData[1]}
                           onNext={() => {}}
                           onPrev={() => {}}
-                          showSideIncome={values.showSideIncome}
+                          showSideIncome={flags.showSideIncome}
                           setShowSideIncome={setShowSideIncome}
-                          showHouseholdMembers={values.showHouseholdMembers}
+                          showHouseholdMembers={flags.showHouseholdMembers}
                           setShowHouseholdMembers={setShowHouseholdMembers}
                           loading={transitionLoading || initLoading}
                         />

--- a/Frontend/src/components/organisms/overlays/wizard/validation/handleStepValidation.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/validation/handleStepValidation.tsx
@@ -1,11 +1,11 @@
 import { validateStepBudgetInfo } from "@components/organisms/overlays/wizard/validation/validateBudgetInfo";
 import { validateStepExpenditure } from "@components/organisms/overlays/wizard/validation/validateStepExpenditure";
 
-
 export const handleStepValidation = async (
   step: number,
   stepRefs: Record<number, any>,
-  setValues: (values: any) => void
+  setShowSideIncome: (value: boolean) => void,
+  setShowHouseholdMembers: (value: boolean) => void,
 ) => {
   const stepRef = stepRefs[step];
   if (!stepRef) return true;
@@ -13,7 +13,7 @@ export const handleStepValidation = async (
   let isValid = false;
   switch (step) {
     case 1:
-      isValid = validateStepBudgetInfo(stepRef, setValues);
+      isValid = validateStepBudgetInfo(stepRef, setShowSideIncome, setShowHouseholdMembers);
       break;
     case 2:
       isValid = validateStepExpenditure(stepRef);
@@ -23,4 +23,3 @@ export const handleStepValidation = async (
   }
   return isValid;
 };
-

--- a/Frontend/src/components/organisms/overlays/wizard/validation/validateBudgetInfo.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/validation/validateBudgetInfo.tsx
@@ -1,18 +1,26 @@
 import { flushSync } from "react-dom";
 
-export const validateStepBudgetInfo = (stepRef: any, setValues: (values: any) => void) => {
+export const validateStepBudgetInfo = (
+  stepRef: any,
+  setShowSideIncome: (value: boolean) => void,
+  setShowHouseholdMembers: (value: boolean) => void,
+) => {
   stepRef.current?.markAllTouched();
   const isValid = stepRef.current?.validateFields();
   const allErrors = stepRef.current?.getErrors() || {};
 
-  // Handle side income errors
-  if (Object.keys(allErrors).some((key) => key.startsWith("sideHustle") || key.startsWith("frequency"))) {
-    flushSync(() => setValues((prev: any) => ({ ...prev, showSideIncome: true })));
+  // Update side income flag if errors exist
+  if (Object.keys(allErrors).some(key => key.startsWith("sideHustle") || key.startsWith("frequency"))) {
+    flushSync(() => {
+      setShowSideIncome(true);
+    });
   }
 
-  // Handle household members errors
-  if (Object.keys(allErrors).some((key) => key.startsWith("memberName") || key.startsWith("memberIncome") || key.startsWith("memberFrequency"))) {
-    flushSync(() => setValues((prev: any) => ({ ...prev, showHouseholdMembers: true })));
+  // Update household members flag if errors exist
+  if (Object.keys(allErrors).some(key => key.startsWith("memberName") || key.startsWith("memberIncome") || key.startsWith("memberFrequency"))) {
+    flushSync(() => {
+      setShowHouseholdMembers(true);
+    });
   }
 
   return isValid;

--- a/Frontend/src/hooks/wizard/flagHooks/useBudgetInfoDisplayFlags.ts
+++ b/Frontend/src/hooks/wizard/flagHooks/useBudgetInfoDisplayFlags.ts
@@ -1,0 +1,25 @@
+import { useState } from "react";
+
+interface BudgetInfoDisplayFlags {
+  showSideIncome: boolean;
+  showHouseholdMembers: boolean;
+}
+
+const useBudgetInfoDisplayFlags = () => {
+  const [flags, setFlags] = useState<BudgetInfoDisplayFlags>({
+    showSideIncome: false,
+    showHouseholdMembers: false,
+  });
+
+  const setShowSideIncome = (value: boolean) => {
+    setFlags((prev) => ({ ...prev, showSideIncome: value }));
+  };
+
+  const setShowHouseholdMembers = (value: boolean) => {
+    setFlags((prev) => ({ ...prev, showHouseholdMembers: value }));
+  };
+
+  return { flags, setShowSideIncome, setShowHouseholdMembers };
+};
+
+export default useBudgetInfoDisplayFlags;


### PR DESCRIPTION
- Updated handleStepValidation to accept setShowSideIncome and setShowHouseholdMembers instead of a single setValues.
- Refactored validateStepBudgetInfo to use individual setters to update side income and household member flags.
- Updated nextStep function to pass the new setter functions.
- Improves modularity and clarity in the wizard validation flow.