### PR TITLE
feat(websocket): implement configurable pong timeout and missed pong …

### DIFF
--- a/Backend.Tests/UnitTests/Services/WizardService/FlowTests/WizardServiceTestsSaveStepData.cs
+++ b/Backend.Tests/UnitTests/Services/WizardService/FlowTests/WizardServiceTestsSaveStepData.cs
@@ -203,7 +203,7 @@ namespace Backend.Tests.UnitTests.Services.WizardService.FlowTests
             {
                 await _wizardService.SaveStepDataAsync("test-session-guid", 1, json);
             });
-            Assert.Contains("Ange namn för inkomsten.", exception.Message);
+            Assert.Contains("Ange namn för sidoinkomst.", exception.Message);
 
             _wizardSqlExecutorMock.Verify(x => x.UpsertStepDataAsync(
                 It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()

--- a/Backend/Application/Settings/WebSocketHealthCheckSettings.cs
+++ b/Backend/Application/Settings/WebSocketHealthCheckSettings.cs
@@ -6,5 +6,7 @@
         public int MinimumActiveConnections { get; set; }
         public int IntervalSeconds { get; set; }
         public int HeartbeatIntervalMinutes { get; set; }
+        public int MissedPongThreshold { get; set; }
+        public bool LogoutOnStaleConnection { get; set; }
     }
 }

--- a/Backend/Infrastructure/WebSockets/WebSocketHandler.cs
+++ b/Backend/Infrastructure/WebSockets/WebSocketHandler.cs
@@ -12,52 +12,20 @@ namespace Backend.Infrastructure.WebSockets
     public class WebSocketHandler : IWebSocketHandler
     {
         private readonly ILogger<WebSocketHandler> _logger;
+        private readonly IWebSocketManager _wsManager; 
 
-        public WebSocketHandler(ILogger<WebSocketHandler> logger)
+        public WebSocketHandler(
+            ILogger<WebSocketHandler> logger,
+            IWebSocketManager wsManager)
         {
             _logger = logger;
+            _wsManager = wsManager;
         }
 
         public async Task HandleAsync(HttpContext context, WebSocket webSocket)
         {
-            var buffer = new byte[1024 * 4];
-            _logger.LogInformation("WebSocket connection established.");
-
-            while (webSocket.State == WebSocketState.Open)
-            {
-                try
-                {
-                    var result = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
-
-                    if (result.MessageType == WebSocketMessageType.Close)
-                    {
-                        _logger.LogInformation("WebSocket connection closing.");
-                        await webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closing", CancellationToken.None);
-                    }
-                    else if (result.MessageType == WebSocketMessageType.Text)
-                    {
-                        var message = Encoding.UTF8.GetString(buffer, 0, result.Count);
-                        _logger.LogInformation($"Received message: {message}");
-
-                        if (message.Equals("logout", StringComparison.OrdinalIgnoreCase))
-                        {
-                            var response = Encoding.UTF8.GetBytes("LOGOUT");
-                            await webSocket.SendAsync(new ArraySegment<byte>(response), WebSocketMessageType.Text, true, CancellationToken.None);
-                            _logger.LogInformation("Sent LOGOUT response.");
-                        }
-
-                        // Handle other messages as needed
-                    }
-                    // Handle other message types if necessary
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "Error occurred while handling WebSocket connection.");
-                    break;
-                }
-            }
-
-            _logger.LogInformation("WebSocket connection closed.");
+            _logger.LogInformation("WebSocketHandler: delegating to WebSocketManager.");
+            await _wsManager.HandleConnectionAsync(webSocket, context);
         }
     }
 }

--- a/Backend/WebSocketHealthCheckSettings.json
+++ b/Backend/WebSocketHealthCheckSettings.json
@@ -3,6 +3,8 @@
     "Enabled": true,
     "MinimumActiveConnections": 1,
     "IntervalSeconds": 30,
-    "HeartbeatIntervalMinutes": 5
+    "HeartbeatIntervalMinutes": 5,
+    "MissedPongThreshold": 3,
+    "LogoutOnStaleConnection": true
   }
 }


### PR DESCRIPTION
…threshold; centralize message handling

- Added configuration settings (MissedPongThreshold, LogoutOnStaleConnection) in WebSocketHealthCheckSettings.json.
- Extended WebSocketConnection with MissedPongCount and updated LastPongTime on pong receipt.
- Updated HealthCheckAsync to increment missed pong counter and forcibly close (or optionally log out) stale connections when the threshold is exceeded.
- Now all incoming messages (ping, pong, logout, etc.) are handled exclusively in the WebSocketManager class.
- Implemented the custom pong feature to respond to health check pings.
- Added new backend tests for both the pong response and forced connection closure scenarios.