### PR TITLE
feat(auth): enhance token validation and caching

### DIFF
--- a/Backend.Tests/IntegrationTests/ControllerTests/AuthControllerIntegrationTests.cs
+++ b/Backend.Tests/IntegrationTests/ControllerTests/AuthControllerIntegrationTests.cs
@@ -25,8 +25,8 @@ namespace Backend.Tests.IntegrationTests.ControllerTests
         public async Task LoginEndpoint_SetsAuthCookies()
         {
             // Arrange: Create and confirm user
-            var (ipAddress, deviceId, userAgent) = AuthTestHelper.GetDefaultMetadata();
-            var userLoginDto = new UserLoginDto { Email = "l@l.se", Password = "Password123!" };
+            var (ipAddress, deviceId, userAgent) = AuthTestHelper.GetDefaultMetadata(); 
+            var userLoginDto = new UserLoginDto { Email = "l@l.se", Password = "Password123!" }; // Use valid credentials
             var registeredUser = await SetupUserAsync();
             await UserServiceTest.ConfirmUserEmailAsync(registeredUser.PersoId);
 

--- a/Backend.Tests/UnitTests/BaseClasses/UnitTestBase.cs
+++ b/Backend.Tests/UnitTests/BaseClasses/UnitTestBase.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
+using Backend.Application.Interfaces.JWT;
 
 public abstract class UnitTestBase
 {
@@ -25,6 +26,7 @@ public abstract class UnitTestBase
     protected Mock<ILogger<UserServices>> LoggerMock;
     protected Mock<IEnvironmentService> MockEnvironmentService;
     protected Mock<IUserTokenService> MockUserTokenService;
+    protected Mock<ITokenBlacklistService> MockTokenBlacklistService;
     protected Mock<HttpContext> MockHttpContext;
     protected Mock<HttpResponse> MockHttpResponse;
     protected UserServices UserServicesInstance;
@@ -52,6 +54,7 @@ public abstract class UnitTestBase
         LoggerMock = new Mock<ILogger<UserServices>>();
         LoggerMockAuth = new Mock<ILogger<UserAuthenticationService>>();
         MockUserTokenService = new Mock<IUserTokenService>();
+        MockTokenBlacklistService = new Mock<ITokenBlacklistService>();
         MockEmailResetPasswordService = new Mock<IEmailResetPasswordService>();
         MockEnvironmentService = new Mock<IEnvironmentService>();
         MockHttpContext = new Mock<HttpContext>();
@@ -120,6 +123,7 @@ public abstract class UnitTestBase
             MockEnvironmentService.Object,
             MockUserTokenService.Object,
             MockEmailResetPasswordService.Object,
+            MockTokenBlacklistService.Object,
             MockHttpContextAccessor.Object,
             MockConfiguration.Object,
             LoggerMockAuth.Object
@@ -177,6 +181,7 @@ public abstract class UnitTestBase
             MockEnvironmentService.Object,          // Mocked IEnvironmentService
             MockUserTokenService.Object,            // Mocked IUserTokenService
             emailResetPasswordService,              // Real IEmailResetPasswordService
+            MockTokenBlacklistService.Object,       // Mocked ITokenBlacklistService
             MockHttpContextAccessor.Object,         // Mocked IHttpContextAccessor
             MockConfiguration.Object,               // Mocked IConfiguration
             LoggerMockAuth.Object                   // Mocked ILogger

--- a/Backend.Tests/UnitTests/Services/UserAuthentication/UserAuthenticationServiceTests.cs
+++ b/Backend.Tests/UnitTests/Services/UserAuthentication/UserAuthenticationServiceTests.cs
@@ -4,7 +4,9 @@ using Backend.Domain.Entities.User;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
+using System.Security.Claims;
 using Xunit;
+using System.IdentityModel.Tokens.Jwt;
 
 namespace Backend.Tests.IntegrationTests.Services.UserAuthentication
 {
@@ -17,11 +19,12 @@ namespace Backend.Tests.IntegrationTests.Services.UserAuthentication
         {
             _userAuthenticationService = new UserAuthenticationService(
                 MockUserSQLProvider.Object, // Mocked provider,
-                MockEnvironmentService.Object,
-                MockUserTokenService.Object,
-                ServiceProvider.GetRequiredService<IEmailResetPasswordService>(),
-                MockHttpContextAccessor.Object,
-                MockConfiguration.Object,
+            MockEnvironmentService.Object,
+            MockUserTokenService.Object,
+            ServiceProvider.GetRequiredService<IEmailResetPasswordService>(),
+            MockTokenBlacklistService.Object,
+            MockHttpContextAccessor.Object,
+            MockConfiguration.Object,
                 LoggerMockAuth.Object
             );
 
@@ -48,9 +51,6 @@ namespace Backend.Tests.IntegrationTests.Services.UserAuthentication
             Assert.True(result, "The method should return true to avoid user enumeration.");
 
         }
-
-
-
 
         [Fact]
         public async Task SendResetPasswordEmailAsync_EmailSendingFails_ReturnsFalse()
@@ -89,10 +89,6 @@ namespace Backend.Tests.IntegrationTests.Services.UserAuthentication
 
         }
 
-
-
-
-
         [Fact]
         public async Task SendResetPasswordEmailAsync_EmailSendingSucceeds_LogsMessageAndReturnsTrue()
         {
@@ -120,6 +116,157 @@ namespace Backend.Tests.IntegrationTests.Services.UserAuthentication
                     It.IsAny<Exception>(),
                     It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)),
                 Times.Once);
+        }
+        [Fact]
+        public async Task CheckAuthStatusAsync_NullUser_ReturnsNotAuthenticated()
+        {
+            // Arrange
+            ClaimsPrincipal user = null;
+
+            // Act
+            var result = await _userAuthenticationService.CheckAuthStatusAsync(user);
+
+            // Assert
+            Assert.False(result.Authenticated);
+        }
+
+        [Fact]
+        public async Task CheckAuthStatusAsync_UserNotAuthenticated_ReturnsNotAuthenticated()
+        {
+            // Arrange: Create a user with an unauthenticated identity.
+            var identity = new ClaimsIdentity(); // No authentication type specified.
+            var user = new ClaimsPrincipal(identity);
+
+            // Act
+            var result = await _userAuthenticationService.CheckAuthStatusAsync(user);
+
+            // Assert
+            Assert.False(result.Authenticated);
+        }
+
+        [Fact]
+        public async Task CheckAuthStatusAsync_MissingJti_ReturnsNotAuthenticated()
+        {
+            // Arrange: Create a user missing the JTI claim.
+            var claims = new List<Claim>
+        {
+            new Claim(JwtRegisteredClaimNames.Email, "test@example.com"),
+            new Claim("role", "User")
+        };
+            var identity = new ClaimsIdentity(claims, "Test");
+            var user = new ClaimsPrincipal(identity);
+
+            // Act
+            var result = await _userAuthenticationService.CheckAuthStatusAsync(user);
+
+            // Assert
+            Assert.False(result.Authenticated);
+        }
+
+        [Fact]
+        public async Task CheckAuthStatusAsync_MissingEmail_ReturnsNotAuthenticated()
+        {
+            // Arrange: Create a user missing the email claim.
+            var claims = new List<Claim>
+        {
+            new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
+            new Claim("role", "User")
+        };
+            var identity = new ClaimsIdentity(claims, "Test");
+            var user = new ClaimsPrincipal(identity);
+
+            // Act
+            var result = await _userAuthenticationService.CheckAuthStatusAsync(user);
+
+            // Assert
+            // If email is missing, the service logs a warning and returns Authenticated = false.
+            Assert.False(result.Authenticated);
+        }
+
+        [Fact]
+        public async Task CheckAuthStatusAsync_TokenBlacklisted_ReturnsNotAuthenticated()
+        {
+            // Arrange: Create a user with a valid email and JTI.
+            string jti = Guid.NewGuid().ToString();
+            var claims = new List<Claim>
+        {
+            new Claim(JwtRegisteredClaimNames.Jti, jti),
+            new Claim(JwtRegisteredClaimNames.Email, "test@example.com"),
+            new Claim("role", "User")
+        };
+            var identity = new ClaimsIdentity(claims, "Test");
+            var user = new ClaimsPrincipal(identity);
+
+            // Set up the blacklist service to return true.
+            MockTokenBlacklistService.Setup(x => x.IsTokenBlacklistedAsync(jti))
+                .ReturnsAsync(true);
+
+            // Act
+            var result = await _userAuthenticationService.CheckAuthStatusAsync(user);
+
+            // Assert
+            Assert.False(result.Authenticated);
+        }
+
+        [Fact]
+        public async Task CheckAuthStatusAsync_AccessTokenDoesNotExist_ReturnsNotAuthenticated()
+        {
+            // Arrange: Create a user with valid claims.
+            string jti = Guid.NewGuid().ToString();
+            var claims = new List<Claim>
+        {
+            new Claim(JwtRegisteredClaimNames.Jti, jti),
+            new Claim(JwtRegisteredClaimNames.Email, "test@example.com"),
+            new Claim("role", "User")
+        };
+            var identity = new ClaimsIdentity(claims, "Test");
+            var user = new ClaimsPrincipal(identity);
+
+            // Configure the blacklist service:
+            // Return false for token blacklisted check.
+            MockTokenBlacklistService.Setup(x => x.IsTokenBlacklistedAsync(jti))
+                .ReturnsAsync(false);
+            // Simulate that the active token check returns false (i.e. token does not exist).
+            MockTokenBlacklistService.Setup(x => x.DoesAccessTokenJtiExistAsync(jti))
+                .ReturnsAsync(false);
+
+            // Act
+            var result = await _userAuthenticationService.CheckAuthStatusAsync(user);
+
+            // Assert
+            Assert.False(result.Authenticated);
+        }
+
+        [Fact]
+        public async Task CheckAuthStatusAsync_ValidToken_ReturnsAuthenticatedStatus()
+        {
+            // Arrange: Create a user with valid claims.
+            string jti = Guid.NewGuid().ToString();
+            string email = "test@example.com";
+            string role = "User";
+            var claims = new List<Claim>
+        {
+            new Claim(JwtRegisteredClaimNames.Jti, jti),
+            new Claim(JwtRegisteredClaimNames.Email, email),
+            new Claim("role", role)
+        };
+            var identity = new ClaimsIdentity(claims, "Test");
+            var user = new ClaimsPrincipal(identity);
+
+            // Configure the blacklist service to indicate the token is not revoked.
+            MockTokenBlacklistService.Setup(x => x.IsTokenBlacklistedAsync(jti))
+                .ReturnsAsync(false);
+            // And simulate that the token exists in the active token table.
+            MockTokenBlacklistService.Setup(x => x.DoesAccessTokenJtiExistAsync(jti))
+                .ReturnsAsync(true);
+
+            // Act
+            var result = await _userAuthenticationService.CheckAuthStatusAsync(user);
+
+            // Assert
+            Assert.True(result.Authenticated);
+            Assert.Equal(email, result.Email);
+            Assert.Equal(role, result.Role);
         }
     }
 }

--- a/Backend.Tests/UnitTests/Services/UserManagement/UserManagementServiceTests.cs
+++ b/Backend.Tests/UnitTests/Services/UserManagement/UserManagementServiceTests.cs
@@ -5,7 +5,7 @@ public class UserManagementServiceTests : UnitTestBase
 {
 
     [Fact]
-    public async void  CheckAuthStatus_ReturnsUnauthenticated_WhenUserIsNotAuthenticated()
+    public async Task CheckAuthStatus_ReturnsUnauthenticated_WhenUserIsNotAuthenticated()
     {
         // Arrange
         var user = new ClaimsPrincipal(new ClaimsIdentity());

--- a/Backend.Tests/UnitTests/Services/UserManagement/UserManagementServiceTests.cs
+++ b/Backend.Tests/UnitTests/Services/UserManagement/UserManagementServiceTests.cs
@@ -5,13 +5,13 @@ public class UserManagementServiceTests : UnitTestBase
 {
 
     [Fact]
-    public void CheckAuthStatus_ReturnsUnauthenticated_WhenUserIsNotAuthenticated()
+    public async void  CheckAuthStatus_ReturnsUnauthenticated_WhenUserIsNotAuthenticated()
     {
         // Arrange
         var user = new ClaimsPrincipal(new ClaimsIdentity());
 
         // Act
-        var result = UserAuthenticationServiceInstance.CheckAuthStatus(user);
+        var result = await UserAuthenticationServiceInstance.CheckAuthStatusAsync(user);
 
         // Assert
         Assert.False(result.Authenticated);
@@ -19,13 +19,13 @@ public class UserManagementServiceTests : UnitTestBase
         Assert.Null(result.Role);
     }
     [Fact]
-    public void CheckAuthStatus_ReturnsUnauthenticated_WhenUserIsNull()
+    public async void CheckAuthStatus_ReturnsUnauthenticated_WhenUserIsNull()
     {
         // Arrange
         ClaimsPrincipal user = null;
 
         // Act
-        var result = UserAuthenticationServiceInstance.CheckAuthStatus(user);
+        var result = await UserAuthenticationServiceInstance.CheckAuthStatusAsync(user);
 
         // Assert
         Assert.False(result.Authenticated);

--- a/Backend/Application/Interfaces/JWT/ITokenBlacklistService.cs
+++ b/Backend/Application/Interfaces/JWT/ITokenBlacklistService.cs
@@ -5,5 +5,6 @@
         Task<bool> BlacklistTokenAsync(string jti, DateTime expiration);
         Task<bool> BlacklistTokenByJtiAsync(string jti, DateTime accessTokenExpiryDate);
         Task<bool> IsTokenBlacklistedAsync(string jti);
+        Task<bool> DoesAccessTokenJtiExistAsync(string accessTokenJti);
     }
 }

--- a/Backend/Application/Interfaces/UserServices/IUserAuthenticationService.cs
+++ b/Backend/Application/Interfaces/UserServices/IUserAuthenticationService.cs
@@ -16,6 +16,6 @@ namespace Backend.Application.Interfaces.UserServices
         Task<bool> SendResetPasswordEmailAsync(string email);
         Task<OperationResult> UpdatePasswordAsync(Guid token, string password);
         Task HandleFailedLoginAsync(UserLoginDto userLoginDto, string ipAddress);
-        AuthStatusDto CheckAuthStatus(ClaimsPrincipal user);
+        Task<AuthStatusDto> CheckAuthStatusAsync(ClaimsPrincipal user);
     }
 }

--- a/Backend/Infrastructure/Data/Sql/Interfaces/UserQueries/IRefreshTokenSqlExecutor.cs
+++ b/Backend/Infrastructure/Data/Sql/Interfaces/UserQueries/IRefreshTokenSqlExecutor.cs
@@ -17,5 +17,6 @@ namespace Backend.Infrastructure.Data.Sql.Interfaces.UserQueries
         Task<bool> DeleteTokensByUserIdAsync(string userId);
         Task<BlacklistedTokenEntity?> GetBlacklistedTokenByJtiAsync(string? jti);
         Task<IEnumerable<RefreshJwtTokenEntity>> GetExpiredTokensAsync();
+        Task<bool> DoesAccessTokenJtiExistAsync(string accessTokenJti);
     }
 }

--- a/Backend/Infrastructure/Implementations/TokenBlacklistService .cs
+++ b/Backend/Infrastructure/Implementations/TokenBlacklistService .cs
@@ -1,6 +1,5 @@
 ﻿// This class handles blacklisting of tokens by adding them to a cache and a database. It also checks if a token is blacklisted.
-// However, due to convience, this class has atleast one method that falls out of the blacklisting scope. This method is used to check if an access token JTI exists.
-
+// However, due to convenience, this class has at least one method that falls out of the blacklisting scope. This method is used to check if an access token JTI exists.
 using Backend.Application.Interfaces.JWT;
 using Backend.Infrastructure.Data.Sql.Interfaces.Providers;
 using Microsoft.Extensions.Caching.Distributed;

--- a/Backend/Infrastructure/WebSockets/WebSocketManager.cs
+++ b/Backend/Infrastructure/WebSockets/WebSocketManager.cs
@@ -413,8 +413,7 @@ namespace Backend.Infrastructure.WebSockets
 
                         if (_logoutOnStaleConnection)
                         {
-                            _logger.LogInformation($"Logging out user {key.UserId} due to stale WebSocket connection.");
-                            await ForceLogoutAsync(key.UserId);
+                            _logger.LogInformation($"Stale WebSocket connection detected for user {key.UserId}. Cleaning up stale connection.");
                         }
                         continue;
                     }

--- a/Backend/Presentation/Controllers/LoginController.cs
+++ b/Backend/Presentation/Controllers/LoginController.cs
@@ -110,12 +110,12 @@ namespace Backend.Presentation.Controllers
 
             return Ok(new { message = "Logged out successfully." });
         }
-
+        // Check if the user is authenticated
         [Authorize]
         [HttpGet("status")]
         public async Task<IActionResult> CheckAuthStatus()
         {
-            var authStatus = _userAuthenticationService.CheckAuthStatus(User);
+            var authStatus = await _userAuthenticationService.CheckAuthStatusAsync(User);
 
             if (authStatus.Authenticated)
             {
@@ -130,6 +130,7 @@ namespace Backend.Presentation.Controllers
             _logger.LogWarning("Unauthorized request. User is not authenticated or claims are missing.");
             return Unauthorized(new AuthStatusDto { Authenticated = false });
         }
+        // Refresh token endpoint
         [AllowAnonymous]
         [HttpPost("refresh")]
         public async Task<IActionResult> RefreshToken()

--- a/Frontend/src/context/AuthProvider.tsx
+++ b/Frontend/src/context/AuthProvider.tsx
@@ -125,7 +125,7 @@ const [wsEnabled, setWsEnabled] = useState(false);
     }
   }, [fetchAuthStatus]);
 
-  // Periodic health check
+  // Periodic status check of user authentication
   useEffect(() => {
     let healthInterval: number | undefined;
     if (authState.authenticated) {
@@ -134,7 +134,7 @@ const [wsEnabled, setWsEnabled] = useState(false);
           const res = await axiosInstance.get("/api/auth/status");
           console.log("Status check successful:", res.data);
         } catch (error) {
-          console.error("Health check error:", error);
+          console.error("status check error:", error);
         }
       }, 60000);
     }


### PR DESCRIPTION
- Updated CheckAuthStatusAsync to verify that the user has an active refresh token using JTI.
- Improved TokenBlacklistService caching to reduce database load for token revocation checks.
- Modified WebSocketManager to no longer force logout on websocket disconnects; it now only logs the event, relying on the auth status poll to log out users without valid access tokens.
- Updated ExpiredTokenScanner to cache its expired tokens query results, reducing resource usage during frequent scans.
- Added new test scenarios for these changes to ensure robust token validation and cleanup.