### PR TITLE
feat: Implement Remember Me and robust session management

### DIFF
--- a/Backend.Tests/IntegrationTests/Services/WebSocketManagerIntegrationTest/WebSocketIntegrationTests.cs
+++ b/Backend.Tests/IntegrationTests/Services/WebSocketManagerIntegrationTest/WebSocketIntegrationTests.cs
@@ -712,7 +712,8 @@ namespace Backend.Tests.IntegrationTests.Services.WebSocketManagerIntegrationTes
                 {
                     Email = registeredUser.Email,
                     Password = "Password123!",
-                    CaptchaToken = "valid-captcha-token"
+                    CaptchaToken = "valid-captcha-token",
+                    RememberMe = true,
                 },
                 ip: "127.0.0.1",
                 deviceId: "test-device",
@@ -818,8 +819,8 @@ namespace Backend.Tests.IntegrationTests.Services.WebSocketManagerIntegrationTes
             // Assert the content of the exception message to confirm it's due to an HTTP 400
             exception.And.Message.Should().Contain("status code '400'",
                 "the server should return a 400 Bad Request due to missing authentication query parameters.");
-            exception.And.Message.Should().Contain("status code '101' was expected'",
-                "this is part of the standard WebSocketException message when the handshake fails at the HTTP level.");
+            exception.And.Message.Should().Contain("status code '101' was expected.", "because...",
+             "this is part of the standard WebSocketException message when the handshake fails at the HTTP level.");
 
             // After ConnectAsync fails, the client's state should be Closed.
             client.State.Should().Be(WebSocketState.Closed,

--- a/Backend.Tests/UnitTests/Services/CookieService/CookieServiceTests.cs
+++ b/Backend.Tests/UnitTests/Services/CookieService/CookieServiceTests.cs
@@ -5,71 +5,183 @@ using Xunit;
 using Backend.Settings;
 using System.Globalization;
 using CookieSvc = Backend.Infrastructure.Services.CookieService.CookieService;
+using Microsoft.Extensions.Hosting;
 
 namespace Backend.Tests.UnitTests.Services.CookieService
 {
-    public class CookieServiceTests : UnitTestBase
+    public class CookieServiceTests
     {
+        private readonly JwtSettings _jwtSettings;
+        private readonly Mock<IWebHostEnvironment> _mockEnv;
+        private readonly HttpContextAccessor _httpContextAccessor;
+
+        public CookieServiceTests()
+        {
+            _jwtSettings = new JwtSettings
+            {
+                RefreshTokenExpiryDaysAbsolute = 30 // Consistent with your CookieService logic
+            };
+
+            _mockEnv = new Mock<IWebHostEnvironment>();
+            // Default to Development for most tests, can be overridden if needed
+            _mockEnv.Setup(env => env.EnvironmentName).Returns(Environments.Development); // Using Environments.Development for type safety
+
+            // HttpContextAccessor needs to be set up for each test with a new DefaultHttpContext
+            // if the Response.Headers are modified and checked.
+            _httpContextAccessor = new HttpContextAccessor();
+        }
+
+        private CookieSvc CreateCookieService(DefaultHttpContext context)
+        {
+            // Ensure the HttpContextAccessor has the context for *this* test run
+            _httpContextAccessor.HttpContext = context;
+            return new CookieSvc(
+                _mockEnv.Object,
+                _httpContextAccessor,
+                _jwtSettings);
+        }
+
         [Fact]
-        public void SetRefreshCookie_ShouldAppendCorrectCookieToResponse()
+        public void SetRefreshCookie_WhenRememberMeIsFalse_ShouldSetSessionCookie()
         {
             // Arrange
-            var jwtSettings = new JwtSettings
-            {
-                // you're using RefreshTokenExpiryDaysAbsolute in BuildOptions
-                RefreshTokenExpiryDaysAbsolute = 30
-            };
-            var defaultContext = new DefaultHttpContext();
-            var httpContextAccessor = new HttpContextAccessor { HttpContext = defaultContext };
-
-            var mockEnv = new Mock<IWebHostEnvironment>();
-            mockEnv.Setup(env => env.EnvironmentName).Returns("Development");
-
-            var cookieService = new CookieSvc(
-                mockEnv.Object,
-                httpContextAccessor,
-                jwtSettings);
-
-            string refreshToken = "test-refresh-token";
+            var defaultContext = new DefaultHttpContext(); // Fresh context for each test
+            var cookieService = CreateCookieService(defaultContext);
+            string refreshToken = "session-refresh-token";
+            bool rememberMe = false;
 
             // Act
-            cookieService.SetRefreshCookie(defaultContext.Response, refreshToken);
+            cookieService.SetRefreshCookie(defaultContext.Response, refreshToken, rememberMe);
 
-            // Grab the first Set-Cookie header
-            var setCookie = defaultContext.Response.Headers["Set-Cookie"].FirstOrDefault();
-            Assert.NotNull(setCookie);
+            // Assert
+            var setCookieHeader = defaultContext.Response.Headers["Set-Cookie"].FirstOrDefault();
+            Assert.NotNull(setCookieHeader);
 
             // 1) Name & value
-            Assert.Contains("RefreshToken=test-refresh-token", setCookie);
+            Assert.Contains($"RefreshToken={refreshToken}", setCookieHeader);
 
-            // 2) Flags
-            Assert.Contains("HttpOnly", setCookie, StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("Secure", setCookie, StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("SameSite=Strict", setCookie, StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("Path=/", setCookie, StringComparison.OrdinalIgnoreCase);
+            // 2) Common Flags
+            Assert.Contains("HttpOnly", setCookieHeader, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Secure", setCookieHeader, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("SameSite=Strict", setCookieHeader, StringComparison.OrdinalIgnoreCase); // Based on your BuildOptions
+            Assert.Contains("Path=/", setCookieHeader, StringComparison.OrdinalIgnoreCase);       // Based on your BuildOptions
 
+            // 3) Development environment should not have Domain attribute (as per your BuildOptions logic)
+            Assert.DoesNotContain("Domain=", setCookieHeader, StringComparison.OrdinalIgnoreCase);
 
-            // 3) Development ⇒ no Domain
-            Assert.DoesNotContain("Domain=", setCookie);
+            // 4) Expires attribute should NOT be present for a session cookie
+            var expiresPart = setCookieHeader
+                .Split(';')
+                .Select(p => p.Trim())
+                .FirstOrDefault(p => p.StartsWith("Expires=", StringComparison.OrdinalIgnoreCase));
 
-            // 4) Expires check
-            //    e.g. …; Expires=Wed, 20 Jun 2025 15:04:05 GMT; …
-            var expiresPart = setCookie
+            Assert.Null(expiresPart); // << KEY CHANGE: Expires should be null for session cookies
+        }
+
+        [Fact]
+        public void SetRefreshCookie_WhenRememberMeIsTrue_ShouldSetPersistentCookieWithExpiry()
+        {
+            // Arrange
+            var defaultContext = new DefaultHttpContext(); // Fresh context for each test
+            var cookieService = CreateCookieService(defaultContext);
+            string refreshToken = "persistent-refresh-token";
+            bool rememberMe = true;
+            var expectedMinExpiry = DateTime.UtcNow.AddDays(_jwtSettings.RefreshTokenExpiryDaysAbsolute).AddMinutes(-1); // Allow for slight clock skew/test execution time
+            var expectedMaxExpiry = DateTime.UtcNow.AddDays(_jwtSettings.RefreshTokenExpiryDaysAbsolute).AddMinutes(1);
+
+            // Act
+            cookieService.SetRefreshCookie(defaultContext.Response, refreshToken, rememberMe);
+
+            // Assert
+            var setCookieHeader = defaultContext.Response.Headers["Set-Cookie"].FirstOrDefault();
+            Assert.NotNull(setCookieHeader);
+
+            // 1) Name & value
+            Assert.Contains($"RefreshToken={refreshToken}", setCookieHeader);
+
+            // 2) Common Flags (repeated for completeness, can be refactored if many tests share this)
+            Assert.Contains("HttpOnly", setCookieHeader, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Secure", setCookieHeader, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("SameSite=Strict", setCookieHeader, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Path=/", setCookieHeader, StringComparison.OrdinalIgnoreCase);
+
+            // 3) Development environment should not have Domain attribute
+            Assert.DoesNotContain("Domain=", setCookieHeader, StringComparison.OrdinalIgnoreCase);
+
+            // 4) Expires attribute SHOULD be present and correct for a persistent cookie
+            var expiresPart = setCookieHeader
+                .Split(';')
+                .Select(p => p.Trim())
+                .FirstOrDefault(p => p.StartsWith("Expires=", StringComparison.OrdinalIgnoreCase));
+
+            Assert.NotNull(expiresPart); // << Expires SHOULD exist
+
+            var expiresValueString = expiresPart!["Expires=".Length..]; // Using ! because we asserted NotNull
+            DateTime expiresUtc = DateTime.ParseExact(
+                expiresValueString,
+                "ddd, dd MMM yyyy HH:mm:ss 'GMT'", // Standard format for cookie Expires
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
+
+            Assert.True(expiresUtc > DateTime.UtcNow, "Cookie Expires should be in the future.");
+            Assert.InRange(expiresUtc, expectedMinExpiry, expectedMaxExpiry);
+        }
+
+        [Fact]
+        public void SetRefreshCookie_WhenEnvironmentIsProductionAndHostMatches_ShouldSetDomain()
+        {
+            // Arrange
+            _mockEnv.Setup(env => env.EnvironmentName).Returns(Environments.Production); // Set to Production
+            var defaultContext = new DefaultHttpContext();
+            defaultContext.Request.Host = new HostString("sub.ebudget.se"); // Set a matching host
+
+            var cookieService = CreateCookieService(defaultContext);
+            string refreshToken = "domain-test-token";
+            bool rememberMe = true; // Persistence doesn't affect domain logic here
+
+            // Act
+            cookieService.SetRefreshCookie(defaultContext.Response, refreshToken, rememberMe);
+
+            // Assert
+            var setCookieHeader = defaultContext.Response.Headers["Set-Cookie"].FirstOrDefault();
+            Assert.NotNull(setCookieHeader);
+            Assert.Contains("Domain=.ebudget.se", setCookieHeader, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void DeleteRefreshCookie_ShouldAppendCookieWithPastExpiry()
+        {
+            // Arrange
+            var defaultContext = new DefaultHttpContext();
+            var cookieService = CreateCookieService(defaultContext);
+
+            // Act
+            cookieService.DeleteRefreshCookie(defaultContext.Response);
+
+            // Assert
+            var setCookieHeader = defaultContext.Response.Headers["Set-Cookie"].FirstOrDefault();
+            Assert.NotNull(setCookieHeader);
+
+            Assert.Contains("RefreshToken=", setCookieHeader); // Name should be present
+            Assert.Contains("Expires=", setCookieHeader, StringComparison.OrdinalIgnoreCase); // Expires should exist
+
+            var expiresPart = setCookieHeader
                 .Split(';')
                 .Select(p => p.Trim())
                 .FirstOrDefault(p => p.StartsWith("Expires=", StringComparison.OrdinalIgnoreCase));
 
             Assert.NotNull(expiresPart);
 
-            // parse with invariant culture
-            var token = expiresPart!["Expires=".Length..];
+            var expiresValueString = expiresPart!["Expires=".Length..];
             DateTime expiresUtc = DateTime.ParseExact(
-                token,
+                expiresValueString,
                 "ddd, dd MMM yyyy HH:mm:ss 'GMT'",
                 CultureInfo.InvariantCulture,
                 DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
 
-            Assert.True(expiresUtc > DateTime.UtcNow, "Cookie Expires should be in the future");
+            // Check if it's a date in the past, e.g., very close to UnixEpoch or significantly before now
+            // Adding a small buffer because AddDays(-1) from UtcNow might be just moments ago.
+            Assert.True(expiresUtc < DateTime.UtcNow.AddSeconds(-10), "Cookie Expires should be in the past for deletion.");
         }
     }
 }

--- a/Backend/Application/Common/Security/UserCtx.cs
+++ b/Backend/Application/Common/Security/UserCtx.cs
@@ -26,7 +26,7 @@
     {
         public sealed record Success(
             AccessTokenResult Access,
-            string RefreshToken, Guid Persoid) : LoginOutcome;
+            string RefreshToken, Guid Persoid, bool RememberMe) : LoginOutcome;
 
         public sealed record Fail(string Error) : LoginOutcome;
     }

--- a/Backend/Application/DTO/Auth/AuthStatusResult.cs
+++ b/Backend/Application/DTO/Auth/AuthStatusResult.cs
@@ -1,20 +1,29 @@
-﻿namespace Backend.Application.DTO.Auth
+﻿using Microsoft.AspNetCore.Http; // Required if CookieOptions were to remain, but we're removing it.
+using System;
+
+namespace Backend.Application.DTO.Auth
 {
     public record AuthStatusResult
     {
         public bool Authenticated { get; init; }
-        public string AccessToken { get; init; }
-        public Guid SessionId { get; init; }
-        public Guid Persoid { get; init; }
-        public DateTime ExpiresUtc { get; init; } // Rolling expiration time for the refresh token
-        public string? NewRefreshCookie { get; init; }
-        public CookieOptions? CookieOptions { get; init; }
+        public string? AccessToken { get; init; } // Nullable if Fail() doesn't provide it
+        public Guid SessionId { get; init; }      // Nullable if Fail() doesn't provide it
+        public Guid Persoid { get; init; }        // Nullable if Fail() doesn't provide it
+        public DateTime ExpiresUtc { get; init; }
+
+        public string? NewRefreshCookie { get; init; } // This is the raw string value of the new refresh token
+        public bool ShouldBePersistent { get; init; } // This flag indicates if the NewRefreshCookie should be set as persistent
 
         public static AuthStatusResult Fail() =>
             new() { Authenticated = false };
 
         public static AuthStatusResult Success(
-            string access, Guid sessionId, Guid persoid, DateTime expiresUtc, string? refreshCookie = null
+            string access,
+            Guid sessionId,
+            Guid persoid,
+            DateTime expiresUtc, // Expiry of AT or RT record in DB
+            bool shouldBePersistent, //  persistence intent
+            string? refreshCookie = null // The new refresh token string
         ) => new()
         {
             Authenticated = true,
@@ -23,16 +32,7 @@
             Persoid = persoid,
             ExpiresUtc = expiresUtc,
             NewRefreshCookie = refreshCookie,
-
-            CookieOptions = refreshCookie == null ? null :
-                                  /* create httpOnly / Secure / SameSite=Strict opts */
-                                  new CookieOptions
-                                  {
-                                      HttpOnly = true,
-                                      Secure = true,
-                                      SameSite = SameSiteMode.Strict,
-                                      Expires = DateTime.UtcNow.AddDays(30) // TODO FIX THIS
-                                  }
+            ShouldBePersistent = shouldBePersistent
         };
     }
 }

--- a/Backend/Application/DTO/User/UserLoginDto.cs
+++ b/Backend/Application/DTO/User/UserLoginDto.cs
@@ -5,6 +5,7 @@
         public string? Email { get; set; }
         public string? Password { get; set; }
         public string? CaptchaToken { get; set; }
+        public bool RememberMe { get; set; }
 
     }
 }

--- a/Backend/Application/Interfaces/AuthService/IAuthService.cs
+++ b/Backend/Application/Interfaces/AuthService/IAuthService.cs
@@ -14,6 +14,6 @@ namespace Backend.Application.Interfaces.AuthService
 
         // RefreshToken and check access token
         Task<AuthStatusResult> CheckAndRefreshAsync(string accessToken, string refreshCookie, Guid sessionId, string userAgent, string deviceId, DbConnection cn, DbTransaction tx);
-        Task<(string token, Guid tokenId, DateTime exp)> IssueAsync(UserCtx ctx, string jti);
+        Task<(string token, Guid tokenId, DateTime exp)> IssueAsync(UserCtx ctx, string jti, bool rememberMe);
     }
 }

--- a/Backend/Application/Interfaces/Cookies/ICookieService.cs
+++ b/Backend/Application/Interfaces/Cookies/ICookieService.cs
@@ -2,7 +2,7 @@
 {
     public interface ICookieService
     {
-        void SetRefreshCookie(HttpResponse res, string token);
+        void SetRefreshCookie(HttpResponse res, string token, bool rememberMe);
         void DeleteRefreshCookie(HttpResponse res);
 
     }

--- a/Backend/Application/Mappers/RefreshTokenMapper.cs
+++ b/Backend/Application/Mappers/RefreshTokenMapper.cs
@@ -25,6 +25,7 @@ public static class RefreshTokenMapper
                   e.ExpiresAbsoluteUtc,
                   e.RevokedUtc,
                   e.Status,
+                  e.IsPersistent,
                   e.DeviceId,
                   e.UserAgent,
                   e.CreatedUtc);
@@ -47,6 +48,7 @@ public static class RefreshTokenMapper
             ExpiresAbsoluteUtc = m.ExpiresAbsoluteUtc,
             RevokedUtc = m.RevokedUtc,
             Status = m.Status,
+            IsPersistent = m.IsPersistent,
             DeviceId = m.DeviceId,
             UserAgent = m.UserAgent,
             CreatedUtc = createdUtcOverride ?? m.CreatedUtc

--- a/Backend/Application/Models/Token/JwtRefreshTokenModel.cs
+++ b/Backend/Application/Models/Token/JwtRefreshTokenModel.cs
@@ -19,6 +19,7 @@ namespace Backend.Application.Models.Token
         DateTime ExpiresAbsoluteUtc, // hard cap – never extended
         DateTime? RevokedUtc,        // set when user/device logs out
         TokenStatus Status,                // 0 = Inactive, 1 = Active, 2 = Revoked
+        bool IsPersistent,        // true = persistent cookie, false = session cookie
         string? DeviceId,           // optional telemetry
         string? UserAgent,          // optional telemetry
         DateTime CreatedUtc          // audit baseline

--- a/Backend/Infrastructure/Data/Sql/Queries/UserQueries/RefreshTokenSqlExecutor.cs
+++ b/Backend/Infrastructure/Data/Sql/Queries/UserQueries/RefreshTokenSqlExecutor.cs
@@ -36,11 +36,11 @@ namespace Backend.Infrastructure.Data.Sql.Queries.UserQueries
             const string sql = @"
             INSERT INTO RefreshTokens
               (TokenId, Persoid, SessionId, HashedToken, AccessTokenJti,
-               ExpiresRollingUtc, ExpiresAbsoluteUtc, RevokedUtc, Status,
+               ExpiresRollingUtc, ExpiresAbsoluteUtc, RevokedUtc, Status, IsPersistent,
                DeviceId, UserAgent, CreatedUtc)
             VALUES
               (@TokenId, @Persoid, @SessionId, @HashedToken, @AccessTokenJti,
-               @ExpiresRollingUtc, @ExpiresAbsoluteUtc, @RevokedUtc, @Status,
+               @ExpiresRollingUtc, @ExpiresAbsoluteUtc, @RevokedUtc, @Status, @IsPersistent,
                @DeviceId, @UserAgent, @CreatedUtc)
             ON DUPLICATE KEY UPDATE
               HashedToken        = VALUES(HashedToken),
@@ -66,6 +66,7 @@ namespace Backend.Infrastructure.Data.Sql.Queries.UserQueries
                 ExpiresAbsoluteUtc = token.ExpiresAbsoluteUtc,
                 RevokedUtc = token.RevokedUtc,
                 Status = token.Status,
+                IsPersistent = token.IsPersistent,
                 token.DeviceId,
                 token.UserAgent,
                 CreatedUtc = token.CreatedUtc
@@ -99,6 +100,7 @@ namespace Backend.Infrastructure.Data.Sql.Queries.UserQueries
                     ExpiresRollingUtc,
                     ExpiresAbsoluteUtc,
                     Status,
+                    IsPersistent,
                     RevokedUtc,
                     DeviceId,
                     UserAgent,

--- a/Backend/Infrastructure/Data/SqlCode/MariaDB/CreateTables.sql
+++ b/Backend/Infrastructure/Data/SqlCode/MariaDB/CreateTables.sql
@@ -150,6 +150,7 @@ CREATE TABLE RefreshTokens (
     ExpiresAbsoluteUtc  DATETIME     NOT NULL,
     RevokedUtc          DATETIME      NULL,          -- null ⇒ still usable
     Status              INT          NOT NULL,       -- 0 = Inactive, 1 = Active, 2 = Revoked
+    IsPersistent        BOOLEAN     NOT NULL DEFAULT FALSE,
 
     DeviceId            VARCHAR(255),
     UserAgent           VARCHAR(255),
@@ -178,6 +179,7 @@ CREATE TABLE RefreshTokens_Archive (
     ExpiresAbsoluteUtc  DATETIME     NOT NULL,
     RevokedUtc          DATETIME      NULL,
     Status              INT          NOT NULL,
+    IsPersistent        BOOLEAN     NOT NULL DEFAULT FALSE,
     DeviceId            VARCHAR(255),
     UserAgent           VARCHAR(255),
     CreatedUtc          DATETIME     NOT NULL,
@@ -194,11 +196,11 @@ FOR EACH ROW
 BEGIN
   INSERT INTO RefreshTokens_Archive
     (TokenId, Persoid, SessionId, HashedToken, AccessTokenJti,
-     ExpiresRollingUtc, ExpiresAbsoluteUtc, RevokedUtc, Status,
+     ExpiresRollingUtc, ExpiresAbsoluteUtc, RevokedUtc, Status, IsPersistent,
      DeviceId, UserAgent, CreatedUtc, ArchivedAt)
   VALUES
     (OLD.TokenId, OLD.Persoid, OLD.SessionId, OLD.HashedToken, OLD.AccessTokenJti,
-     OLD.ExpiresRollingUtc, OLD.ExpiresAbsoluteUtc, OLD.RevokedUtc, OLD.Status,
+     OLD.ExpiresRollingUtc, OLD.ExpiresAbsoluteUtc, OLD.RevokedUtc, OLD.Status, OLD.IsPersistent,
      OLD.DeviceId, OLD.UserAgent, OLD.CreatedUtc, NOW());
 END$$
 DELIMITER ;

--- a/Backend/Infrastructure/Entities/Tokens/RefreshJwtTokenEntity.cs
+++ b/Backend/Infrastructure/Entities/Tokens/RefreshJwtTokenEntity.cs
@@ -16,6 +16,7 @@
         public DateTime ExpiresAbsoluteUtc { get; init; }                 // hard cap
         public DateTime? RevokedUtc { get; set; }                  // NULL = active
         public TokenStatus Status { get; set; } = TokenStatus.Active;
+        public bool IsPersistent { get; init; } 
 
         /* Telemetry (optional) */
         public string? DeviceId { get; init; }

--- a/Backend/Presentation/Controllers/LoginController.cs
+++ b/Backend/Presentation/Controllers/LoginController.cs
@@ -72,7 +72,7 @@ namespace Backend.Presentation.Controllers
 
                 case LoginOutcome.Success s:
                     _logger.LogInformation("Login successful for user: {MaskedEmail}", LogHelper.MaskEmail(dto.Email));
-                    cookieService.SetRefreshCookie(Response, s.RefreshToken);
+                    cookieService.SetRefreshCookie(Response, s.RefreshToken, s.RememberMe);
                     var wsMac = WebSocketAuth.MakeWsMac(s.Access.Persoid, s.Access.SessionId, _wsCfg.Secret);
                     return Ok(new AuthResult(true,
                                              s.Access.Token,
@@ -148,7 +148,7 @@ namespace Backend.Presentation.Controllers
 
             /* 5 ─ set new refresh cookie, if rotated */
             if (result.NewRefreshCookie is not null)
-                cookieService.SetRefreshCookie(Response, result.NewRefreshCookie);
+                cookieService.SetRefreshCookie(Response, result.NewRefreshCookie, result.ShouldBePersistent);
             _logger.LogInformation("Refresh successful for persoid: {Persoid}:", result.Persoid);
             /* 6 ─ return AuthResult + WsMac */
             var wsMac = WebSocketAuth.MakeWsMac(result.Persoid, result.SessionId, _wsCfg.Secret);

--- a/Frontend/src/App.tsx
+++ b/Frontend/src/App.tsx
@@ -13,7 +13,7 @@ import { useAuthWs }      from '@/hooks/auth/useAuthWs';
  * @returns {JSX.Element} The main App component.
  */
 export default function App() {
-  useAuthWs();                        // safe: this runs only after AuthProvider is "ready"
+  useAuthWs();                        // safe: this runs only after AuthProvider is "setProviderReady"
 
   return (
     <BrowserRouter>

--- a/Frontend/src/Pages/auth/LoginPage.tsx
+++ b/Frontend/src/Pages/auth/LoginPage.tsx
@@ -29,7 +29,9 @@ export default function LoginPage() {
   const [form, setForm] = useState<UserLoginDto>({ email: '', password: '', captchaToken: '' });
   const [err, setErr] = useState<Record<string, string>>({});
   const [sub, setSub] = useState(false);
-  const [rememberMe, setRememberMe] = useState(false); // State for the checkbox
+  // State to track whether the user wants to be remembered on this device.
+  // Default value is `false` to ensure users explicitly opt in.
+  const [rememberMe, setRememberMe] = useState(false);
   const capRef = useRef<ReCAPTCHAWithReset>(null);
 
   const nav = useNavigate();

--- a/Frontend/src/Pages/auth/LoginPage.tsx
+++ b/Frontend/src/Pages/auth/LoginPage.tsx
@@ -1,70 +1,69 @@
-// src/pages/LoginPage.tsx
-import React, { useRef, useState }     from 'react'
-import { Navigate, useNavigate }       from 'react-router-dom'
-import ReCAPTCHA                       from 'react-google-recaptcha'
-import { object, string }              from 'yup'
+import React, { useRef, useState } from 'react';
+import { Navigate, useNavigate } from 'react-router-dom';
+import ReCAPTCHA from 'react-google-recaptcha';
+import { object, string } from 'yup';
 
-import { useAuth }                     from '@/hooks/auth/useAuth'
-import type { UserLoginDto }           from '@myTypes/User/Auth/userLoginForm'
+import { useAuth } from '@/hooks/auth/useAuth';
+import type { UserLoginDto } from '@myTypes/User/Auth/userLoginForm';
 
-import PageContainer    from '@components/layout/PageContainer'
-import ContentWrapper   from '@components/layout/ContentWrapper'
-import CenteredContainer from '@components/atoms/container/CenteredContainer'
-import LoadingScreen     from '@components/molecules/feedback/LoadingScreen'
-import FormContainer     from '@components/molecules/containers/FormContainer'
-import InputField        from '@components/atoms/InputField/ContactFormInputField'
-import SubmitButton      from '@components/atoms/buttons/SubmitButton'
-import LoginBird         from '@assets/Images/LoginBird.png'
+import PageContainer from '@components/layout/PageContainer';
+import ContentWrapper from '@components/layout/ContentWrapper';
+import CenteredContainer from '@components/atoms/container/CenteredContainer';
+import LoadingScreen from '@components/molecules/feedback/LoadingScreen';
+import FormContainer from '@components/molecules/containers/FormContainer';
+import InputField from '@components/atoms/InputField/ContactFormInputField';
+import SubmitButton from '@components/atoms/buttons/SubmitButton';
+import Checkbox from '@components/atoms/boxes/Checkbox';
+import LoginBird from '@assets/Images/LoginBird.png';
 
 /* —— yup schema —— */
 const schema = object({
-  email       : string().email('Ogiltig e-post').required('E-post krävs'),
-  password    : string().min(6,'Minst 6 tecken').required('Lösenord krävs'),
+  email: string().email('Ogiltig e-post').required('E-post krävs'),
+  password: string().min(6, 'Minst 6 tecken').required('Lösenord krävs'),
   captchaToken: string().required('Captcha krävs'),
-})
+});
 
-type ReCAPTCHAWithReset = ReCAPTCHA & { reset:()=>void }
+type ReCAPTCHAWithReset = ReCAPTCHA & { reset: () => void };
 
 export default function LoginPage() {
-  const [form, setForm]   = useState<UserLoginDto>({ email:'', password:'', captchaToken:'' })
-  const [err,  setErr]    = useState<Record<string,string>>({})
-  const [sub,  setSub]    = useState(false)
-  const capRef            = useRef<ReCAPTCHAWithReset>(null)
+  const [form, setForm] = useState<UserLoginDto>({ email: '', password: '', captchaToken: '' });
+  const [err, setErr] = useState<Record<string, string>>({});
+  const [sub, setSub] = useState(false);
+  const [rememberMe, setRememberMe] = useState(false); // State for the checkbox
+  const capRef = useRef<ReCAPTCHAWithReset>(null);
 
-  const nav               = useNavigate()
-  const { login, isLoading, accessToken } = useAuth()
+  const nav = useNavigate();
+  const { login, isLoading, accessToken } = useAuth();
 
-  /* redirects */
-  if (isLoading)  return <CenteredContainer><LoadingScreen/></CenteredContainer>
-  if (accessToken) return <Navigate to="/dashboard" replace />
+  if (isLoading) return <CenteredContainer><LoadingScreen /></CenteredContainer>;
+  if (accessToken) return <Navigate to="/dashboard" replace />;
 
-  /* helpers */
-  const setField = (k:keyof UserLoginDto,v:string)=>
-    setForm(f=>({...f,[k]:v}))
+  const setField = (k: keyof UserLoginDto, v: string) =>
+    setForm(f => ({ ...f, [k]: v }));
 
   const validate = async () => {
-    try { await schema.validate(form,{abortEarly:false}); setErr({}); return true }
-    catch (e:any) {
-      const map:Record<string,string>={}
-      e.inner?.forEach((m:any)=>{ map[m.path]=m.message })
-      setErr(map); return false
+    try { await schema.validate(form, { abortEarly: false }); setErr({}); return true; }
+    catch (e: any) {
+      const map: Record<string, string> = {};
+      e.inner?.forEach((m: any) => { map[m.path] = m.message; });
+      setErr(map); return false;
     }
-  }
+  };
 
-  const onSubmit = async (e:React.FormEvent) => {
-    e.preventDefault()
-    if (!(await validate())) return
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!(await validate())) return;
 
-    setSub(true)
-    const res = await login(form)
-    setSub(false)
+    setSub(true);
+    // Pass the rememberMe state to the login function
+    const res = await login(form, rememberMe);
+    setSub(false);
 
-    if (res.success) return nav('/dashboard',{replace:true})
-    setErr({ form: res.message })
-    capRef.current?.reset()
-  }
+    if (res.success) return nav('/dashboard', { replace: true });
+    setErr({ form: res.message });
+    capRef.current?.reset();
+  };
 
-  /* render */
   return (
     <PageContainer centerChildren>
       <ContentWrapper className='2xl:pt-[5%]' centerContent>
@@ -75,32 +74,40 @@ export default function LoginPage() {
             Välkommen tillbaka! Logga in för att fortsätta
           </p>
 
-          {/* email */}
           <label className='block mb-2 text-sm'>E-postadress</label>
           <InputField value={form.email} placeholder='Ange e-post'
-                      onChange={e=>setField('email',e.target.value)} width='100%'/>
+                      onChange={e => setField('email', e.target.value)} width='100%' />
           {err.email && <p className='text-sm text-red-500'>{err.email}</p>}
 
-          {/* password */}
           <label className='block mt-4 mb-2 text-sm'>Lösenord</label>
           <InputField type='password' value={form.password} placeholder='Ange lösenord'
-                      onChange={e=>setField('password',e.target.value)} width='100%'/>
+                      onChange={e => setField('password', e.target.value)} width='100%' />
           {err.password && <p className='text-sm text-red-500'>{err.password}</p>}
+
+          {/* Remember Me Checkbox */}
+          <div className="mt-4 mb-4 flex items-center">
+            <Checkbox
+              id="remember-me"
+              label="Kom ihåg mig"
+              description="Håll mig inloggad på den här enheten i upp till 30 dagar."
+              checked={rememberMe}
+              onChange={e => setRememberMe(e.target.checked)}
+            />
+          </div>
 
           {err.form && <p className='mt-2 text-sm text-red-500'>{err.form}</p>}
 
-          {/* actions */}
           <div className='mt-6 flex flex-col sm:flex-row sm:items-center sm:space-x-4'>
-            <SubmitButton type='submit' label='Logga in' isSubmitting={sub} enhanceOnHover style={{width:'100%'}}/>
+            <SubmitButton type='submit' label='Logga in' isSubmitting={sub} enhanceOnHover style={{ width: '100%' }} />
             <ReCAPTCHA sitekey={import.meta.env.VITE_RECAPTCHA_SITE_KEY}
-                        onChange={tok=>setField('captchaToken',tok||'')}
-                        ref={capRef}/>
+                       onChange={tok => setField('captchaToken', tok || '')}
+                       ref={capRef} />
           </div>
         </FormContainer>
 
         <img src={LoginBird} loading='lazy' alt=''
-             className='z-0 mt-10 mx-auto max-w-[180px] lg:absolute lg:right-10 lg:top-3/4 lg:-translate-y-1/2 xl:max-w-[350px]'/>
+             className='z-0 mt-10 mx-auto max-w-[180px] lg:absolute lg:right-10 lg:top-3/4 lg:-translate-y-1/2 xl:max-w-[350px]' />
       </ContentWrapper>
     </PageContainer>
-  )
+  );
 }

--- a/Frontend/src/api/Auth/auth.ts
+++ b/Frontend/src/api/Auth/auth.ts
@@ -22,7 +22,8 @@ export async function refreshToken(): Promise<string> {
       accessToken: currentAccessToken },
     { headers: { 'X-Session-Id': sessionId ?? '' } });
 
-  if (!data.success || !data.accessToken || !data.persoid) { // also check persoid
+  // Ensure the response includes 'persoid', which is required for identifying the user session.
+  if (!data.success || !data.accessToken || !data.persoid) {
     throw new Error('refresh failed');
   }
 

--- a/Frontend/src/components/atoms/boxes/Checkbox.module.css
+++ b/Frontend/src/components/atoms/boxes/Checkbox.module.css
@@ -1,0 +1,84 @@
+/* Wrapper keeps label pointer-friendly */
+.checkbox {
+  cursor: pointer;
+}
+
+/* Native checkbox – visually hidden but accessible */
+.checkbox_input {
+  position: absolute;
+  width: 0;
+  height: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* Custom square ------------------------------------------------------ */
+.checkbox_check {
+  width: 25px;
+  height: 25px;
+  box-sizing: border-box;
+  border: 0.2rem solid #32CD32;            /* brand dark-lime-green */
+  border-radius: 0.25rem;
+  background: transparent;
+  will-change: transform;                  /* hint GPU */
+  transition:
+    transform 250ms cubic-bezier(.22,1,.36,1),
+    background 400ms ease,
+    box-shadow 250ms ease;
+}
+
+/* Tick polyline – ghost-tick by default ----------------------------- */
+.checkbox_check polyline {
+  --ghost-colour: rgba(50 205 50 / .45);   /* brand @45 % alpha */
+  stroke: var(--ghost-colour);
+  stroke-dasharray: 25;
+  stroke-dashoffset: 25;                   /* hidden */
+  stroke-linecap: round;
+  stroke-width: 0.2em;
+  fill: none;
+  transition: stroke-dashoffset .4s ease,  /* draw/undraw */
+              stroke            .2s ease;  /* colour swap */
+}
+
+/* Checked – box fills & tick turns white ---------------------------- */
+.checkbox_input:checked + .checkbox_check {
+  background: #32CD32;
+}
+.checkbox_input:checked + .checkbox_check polyline {
+  stroke: #fff;
+  stroke-dashoffset: 0;                    /* stay drawn */
+}
+
+/* Hover – lift & ghost-tick preview --------------------------------- */
+.checkbox:hover .checkbox_check {
+  transform: translateY(-1px) scale(1.05);
+  box-shadow: 0 4px 8px rgba(50 205 50 / .35);
+}
+/* draw the ghost only if currently unchecked */
+.checkbox:hover input:not(:checked) + .checkbox_check polyline {
+  stroke-dashoffset: 0;
+}
+
+/* tiniest delay so ghost erases smoothly on mouse-leave */
+.checkbox input:not(:checked) + .checkbox_check polyline {
+  transition-delay: .05s;
+}
+
+/* Press feedback ----------------------------------------------------- */
+.checkbox_input:active + .checkbox_check {
+  transform: scale(.96);
+}
+
+/* Keyboard focus (WCAG 2.2) ----------------------------------------- */
+.checkbox_input:focus-visible + .checkbox_check {
+  outline: 2px solid #98FF98;
+  outline-offset: 2px;
+}
+
+/* Motion-safe fallback ---------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  .checkbox_check,
+  .checkbox_check polyline {
+    transition: none;
+  }
+}

--- a/Frontend/src/components/atoms/boxes/Checkbox.tsx
+++ b/Frontend/src/components/atoms/boxes/Checkbox.tsx
@@ -1,0 +1,123 @@
+import React, { forwardRef, ComponentPropsWithoutRef, useId } from "react";
+import styles from "./Checkbox.module.css";
+
+export interface CheckboxProps
+  extends Omit<ComponentPropsWithoutRef<"input">, "type" | "className"> {
+  /** Main label text */
+  label?: React.ReactNode;
+  /** Helper/description text */
+  description?: React.ReactNode;
+  /** Extra classes for the outermost wrapper div */
+  className?: string;
+  /** Extra classes for label text span */
+  labelClassName?: string;
+  /** Extra classes for description text span */
+  descriptionClassName?: string;
+}
+
+const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
+  (
+    {
+      id: propId,
+      name,
+      label: labelText, // Internally aliased from 'label' prop
+      description,
+      className = "",
+      labelClassName = "",
+      descriptionClassName = "",
+      checked,
+      onChange,
+      ...rest
+    },
+    ref
+  ) => {
+    const reactGeneratedId = useId(); // React 18+ for unique IDs
+    // Ensure a unique ID for the input, critical for htmlFor.
+    // If not on React 18, you MUST pass a unique 'id' prop.
+    const inputId = propId || name || reactGeneratedId;
+
+    const multiLine = !!description;
+
+    return (
+      // 1. Outermost wrapper DIV.
+      // This div controls the side-by-side layout of the [Checkbox Visual] and [Text Content].
+      // Tailwind's `inline-flex` should arrange its children in a row.
+      // `items-start` aligns the top of the checkbox with the top of the text.
+      <div
+        className={`
+          inline-flex 
+          ${multiLine ? 'items-start' : 'items-center'} 
+          gap-3 
+          select-none 
+          ${className} {/* User-provided classes for the whole component wrapper */}
+        `}
+      >
+        {/* 2. Clickable Checkbox Area (The Visual Part)
+               This <label> wraps the hidden input and the SVG.
+               It gets `styles.checkbox` for cursor and hover parent.
+               It's sized to match your SVG's dimensions. */}
+        <label
+          htmlFor={inputId}
+          className={`
+            ${styles.checkbox} {/* From your CSS: cursor: pointer; */}
+            relative      {/* For the absolutely positioned input inside */}
+            flex-shrink-0 {/* Prevents this label from shrinking */}
+            w-[25px]      {/* Matches your .checkbox_check width */}
+            h-[25px]      {/* Matches your .checkbox_check height */}
+
+          `}
+        >
+          <input
+            ref={ref}
+            id={inputId}
+            name={name}
+            type="checkbox"
+            checked={checked}
+            onChange={onChange}
+            // `styles.checkbox_input` from your CSS makes this hidden and non-interactive.
+            className={styles.checkbox_input}
+            {...rest}
+          />
+          {/* The SVG is the visual representation.
+              It's an immediate sibling to the input, satisfying .input:checked + .check */}
+          <svg
+            // `styles.checkbox_check` from your CSS styles the box and tick.
+            className={styles.checkbox_check}
+            width={25} // Explicit width/height also on SVG element
+            height={25} // for clarity and consistency
+            viewBox="0 0 25 25" // Ensure viewBox matches if your SVG paths depend on it.
+            aria-hidden="true"
+          >
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
+        </label>
+
+        {/* 3. Textual Content Area
+               This div is a sibling to the clickable <label> above.
+               Clicks here will NOT affect the checkbox state. */}
+        {(labelText || description) && (
+          <div className="flex flex-col flex-1 min-w-0">
+            {labelText && (
+              <span
+                className={`text-sm font-medium text-gray-500 ${labelClassName}`}
+              >
+                {labelText}
+              </span>
+            )}
+            {description && (
+              <span
+                className={`mt-0.5 text-xs text-gray-400 ${descriptionClassName}`}
+              >
+                {description}
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  }
+);
+
+Checkbox.displayName = "Checkbox";
+
+export default Checkbox;

--- a/Frontend/src/components/atoms/dropdown/SelectDropdown.tsx
+++ b/Frontend/src/components/atoms/dropdown/SelectDropdown.tsx
@@ -36,7 +36,7 @@ const SelectDropdown = forwardRef<HTMLSelectElement, SelectDropdownProps>(
         {label && (
           <label
             htmlFor={id || name} 
-            className="block mt-4 text-sm font-medium text-gray-700 dark:text-gray-200" 
+            className="block mt-4 text-sm font-medium text-gray-700 dark:text-gray-200" //TODO FIX THIS
           >
             {label}
           </label>

--- a/Frontend/src/hooks/auth/useAuth.ts
+++ b/Frontend/src/hooks/auth/useAuth.ts
@@ -1,40 +1,66 @@
 import { useCallback } from 'react';
-import { api } from '@/api/axios';
-import { callLogin, callLogout } from '@/api/Auth/auth';
 import { useAuthStore } from '@/stores/Auth/authStore';
-import { UserLoginDto } from '@/types/User/Auth/userLoginForm';
-import { LoginRes } from '@/types/User/Auth/authTypes';
-import { UserDto } from '@/types/User/UserDto';
+import { callLogin, callLogout } from '@/api/Auth/auth';
+import { api } from '@/api/axios';
+import type { UserLoginDto } from '@myTypes/User/Auth/userLoginForm';
+import type { LoginRes } from '@/types/User/Auth/authTypes';
+import type { UserDto } from '@myTypes/User/UserDto';
 
 export function useAuth() {
-  const store = useAuthStore();
+  // Select actions and specific state pieces for stability and clarity
+  const setAuthAction = useAuthStore(s => s.setAuth);
+  const mergeUserAction = useAuthStore(s => s.mergeUser);
+  const currentAccessToken = useAuthStore(s => s.accessToken);
+  const currentUser = useAuthStore(s => s.user);
+  const isAuthInitialized = useAuthStore(s => s.authProviderInitialized);
+  const currentRememberMe = useAuthStore(s => s.rememberMe);
 
-  /* —— login —— */
-  const login = useCallback(async (dto: UserLoginDto): Promise<LoginRes> => {
-    const res = await callLogin(dto);
-    if (!res.success || !res.sessionId || !res.accessToken) return res;
+  const login = useCallback(async (dto: UserLoginDto, rememberMe: boolean): Promise<LoginRes> => {
+    const res = await callLogin(dto, rememberMe); // Assuming callLogin now takes rememberMe
 
-    store.setAuth(res.accessToken, res.sessionId, res.persoid, res.wsMac);
+    if (!res.success || !res.sessionId || !res.accessToken || !res.persoid) {
+      // If login is not successful, but we want to ensure store reflects an initialized state (e.g. to show login page)
+      // This depends on whether callLogin failing should still mark auth as "initialized"
+      // For now, assuming AuthProvider handles the base initialization.
+      return res;
+    }
+
+    // Pass rememberMe to the store when setting auth data
+    // Ensure wsMac is handled correctly (null if undefined)
+    setAuthAction(res.accessToken, res.sessionId, res.persoid, res.wsMac ?? null, rememberMe);
     api.defaults.headers.common.Authorization = `Bearer ${res.accessToken}`;
+
+    // The logic for setting appSessionActive was moved to the store's setAuth action
+    // for better centralization, but can also be here if preferred.
+    // If it's in the store, remove these lines:
+    // if (!rememberMe) {
+    //   sessionStorage.setItem('appSessionActive', 'true');
+    // } else {
+    //   sessionStorage.removeItem('appSessionActive');
+    // }
 
     try {
       const { data: me } = await api.get<UserDto>('/api/users/me');
-      store.mergeUser(me);
-    } catch {/* ignore */ }
+      mergeUserAction(me);
+    } catch (err) {
+      console.error("Failed to fetch user details after login:", err);
+      // Potentially clear user data or handle error if this is critical
+    }
 
     return res;
-  }, [store]);
+  }, [setAuthAction, mergeUserAction]); // Dependencies are stable store actions
 
-  /* —— logout —— */
   const logout = useCallback(async () => {
-    await callLogout();          // clears store inside helper
-  }, []);
+    await callLogout(); // callLogout should handle clearing store (which sets authProviderInitialized=true)
+  }, []); // callLogout is stable, no need to list store actions if it uses getState()
 
   return {
-    accessToken : store.accessToken,
-    user        : store.user,
-    authenticated: !!store.accessToken,
-    isLoading     : store.isLoading,
-    login, logout,
+    accessToken: currentAccessToken,
+    user: currentUser,
+    authenticated: !!currentAccessToken,
+    isLoading: !isAuthInitialized, //isLoading is true if AuthProvider is NOT yet initialized
+    rememberMe: currentRememberMe,
+    login,
+    logout,
   };
 }

--- a/Frontend/src/routes/ProtectedRoute.tsx
+++ b/Frontend/src/routes/ProtectedRoute.tsx
@@ -3,10 +3,11 @@ import { useAuthStore } from '@/stores/Auth/authStore';
 import LoadingScreen from '@components/molecules/feedback/LoadingScreen';
 
 const ProtectedRoute = () => {
-  const { ready, accessToken } = useAuthStore();
+  const isAuthInitialized = useAuthStore(state => state.authProviderInitialized);
+  const accessToken = useAuthStore(state => state.accessToken);
   const isDebugMode = process.env.NODE_ENV === 'development';
   
-  if (!ready && !isDebugMode) { // Only show loading if not in debug and not ready
+  if (!isAuthInitialized  && !isDebugMode) { // Only show loading if not in debug and not ready
     return <LoadingScreen />;
   }
 


### PR DESCRIPTION
This commit introduces Remember Me functionality and significantly enhances session persistence logic across the frontend and backend.

Key changes include:
- Added a Remember Me checkbox to the login flow, allowing users to opt for persistent sessions.
- Backend login endpoint now conditionally sets the HttpOnly refresh token cookie:
    - Persistent (with expiry) if Remember Me is checked.
    - Session (no expiry) if Remember Me is unchecked.
- Frontend AuthProvider now:
    - Detects browser restarts for non-persistent sessions (using localStorage and sessionStorage markers).
    - Clears local authentication state (accessToken, sessionDetails from localStorage) if a non-persistent session ends.
- Decoupled AuthProvider's initialization readiness state from WebSocket's connection readiness state in the Zustand store. This resolves previous infinite re-render loops and clarifies state management.
- Updated CookieService unit tests to verify the new conditional cookie expiry logic (session vs. persistent).
- Ensured the Remember Me intent is stored with the refresh token in the database and that this intent is respected when new refresh tokens are issued during rotation.
- Addressed various bugs related to React effect dependencies and Zustand store selectors that were causing unexpected re-renders.