### PR TITLE
feat: Localize backend login error messages for frontend

### DIFF
--- a/Frontend/src/Pages/auth/LoginPage.tsx
+++ b/Frontend/src/Pages/auth/LoginPage.tsx
@@ -15,6 +15,7 @@ import InputField from '@components/atoms/InputField/ContactFormInputField';
 import SubmitButton from '@components/atoms/buttons/SubmitButton';
 import Checkbox from '@components/atoms/boxes/Checkbox';
 import LoginBird from '@assets/Images/LoginBird.png';
+import { translateBackendError } from '@/translations/errorMessages';
 
 /* —— yup schema —— */
 const schema = object({
@@ -62,7 +63,9 @@ export default function LoginPage() {
     setSub(false);
 
     if (res.success) return nav('/dashboard', { replace: true });
-    setErr({ form: res.message });
+    const swedishErrorMessage = translateBackendError(res.message);
+    setErr({ form: swedishErrorMessage }); // Set the error message for the form
+    // Reset the captcha if login fails
     capRef.current?.reset();
   };
 

--- a/Frontend/src/translations/errorMessages.ts
+++ b/Frontend/src/translations/errorMessages.ts
@@ -1,0 +1,15 @@
+const backendErrorTranslations: Record<string, string> = {
+  "Invalid credentials.": "Felaktig e-postadress eller lösenord.",
+  "Email not confirmed.": "E-postadressen är inte bekräftad. Kontrollera din inkorg.",
+   "Account locked.": "Ditt konto är låst. Kontakta supporten för hjälp.",
+  "Login failed": "Inloggningen misslyckades. Försök igen.", 
+  "Network Error": "Nätverksfel. Kontrollera din anslutning och försök igen.",
+
+};
+
+export const translateBackendError = (englishMessage?: string): string => {
+  if (!englishMessage) {
+    return "Ett okänt fel inträffade."; // Default Swedish error
+  }
+  return backendErrorTranslations[englishMessage] || englishMessage; // Fallback to English if no translation
+};

--- a/Frontend/tsconfig.json
+++ b/Frontend/tsconfig.json
@@ -33,7 +33,8 @@
 	  "@routes/*": ["routes/*"],		  
 	  "@styles/*": ["styles/*"],	
 	  "@schemas/*": ["schemas/*"],	  
-	  "@stores/*": ["stores/*"],	  	  
+	  "@stores/*": ["stores/*"],	  	
+	  "@translations/*": ["translations/*"],	  			
     }
   },
   "include": ["src/**/*",]

--- a/Frontend/vite.config.js
+++ b/Frontend/vite.config.js
@@ -56,7 +56,8 @@ export default defineConfig({
 	  '@routes': path.resolve(__dirname, './src/routes'),
 	  '@styles': path.resolve(__dirname, './src/styles'),
 	  '@schemas': path.resolve(__dirname, './src/schemas'),
-	  '@stores': path.resolve(__dirname, './src/stores'),	  
+	  '@stores': path.resolve(__dirname, './src/stores'),	
+	  '@translations': path.resolve(__dirname, './src/translations'),	  
     },
   },
 });


### PR DESCRIPTION
Implements translation of backend login error messages (e.g., Invalid credentials, Email not confirmed) into Swedish for display on the LoginPage.

A new translation utility (	ranslateBackendError) maps known English error strings from the backend API response to their Swedish equivalents. If a translation is not found, the original English message is displayed as a fallback. This enhances user experience by providing error feedback in the application's primary language while allowing the backend to maintain English for its error messages.