### PR TITLE
Implement wizard transport substep

### DIFF
--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/SubStepTransport.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/SubStepTransport.tsx
@@ -1,21 +1,82 @@
 import React from "react";
+import { useFormContext } from "react-hook-form";
+import OptionContainer from "@components/molecules/containers/OptionContainer";
+import Checkbox from "@components/atoms/boxes/Checkbox";
+import FormattedNumberInput from "@components/atoms/InputField/FormattedNumberInput";
 
-interface SubStepTransportProps {
-  initialData?: any;
+interface TransportForm {
+  transport: {
+    hasCar: boolean;
+    monthlyFuelCost: number | null;
+    hasTransitCard: boolean;
+    monthlyTransitCost: number | null;
+  };
 }
 
-const SubStepTransport: React.FC<SubStepTransportProps> = ({ initialData }) => {
+const SubStepTransport: React.FC = () => {
+  const {
+    register,
+    watch,
+    setValue,
+    formState: { errors },
+  } = useFormContext<TransportForm>();
+
+  const hasCar = watch("transport.hasCar");
+  const hasTransit = watch("transport.hasTransitCard");
+
+  const fuelReg = register("transport.monthlyFuelCost");
+  const transitReg = register("transport.monthlyTransitCost");
+
   return (
-    <div className="text-center">
-      <h3 className="text-xl font-semibold mb-2">Transport Information (Dummy)</h3>
-      <p>This is a placeholder for the Transport sub-step.</p>
-      {initialData && (
-        <pre className="bg-gray-100 p-2 mt-2 rounded">
-          {JSON.stringify(initialData, null, 2)}
-        </pre>
-      )}
-    </div>
+    <OptionContainer>
+      <h3 className="text-2xl font-bold text-darkLimeGreen mb-6 text-center">
+        Transportkostnader
+      </h3>
+      <div className="space-y-6">
+        <div>
+          <Checkbox label="Jag har bil" {...register("transport.hasCar")}
+            checked={hasCar} />
+          {hasCar && (
+            <div className="mt-4">
+              <label htmlFor="monthlyFuelCost" className="block text-sm font-medium">
+                Kostnad för drivmedel per månad
+              </label>
+              <FormattedNumberInput
+                id="monthlyFuelCost"
+                value={watch("transport.monthlyFuelCost") ?? 0}
+                onValueChange={(val) => setValue("transport.monthlyFuelCost", val ?? 0)}
+                placeholder="t.ex. 1500 kr"
+                name={fuelReg.name}
+                onBlur={fuelReg.onBlur}
+                error={errors.transport?.monthlyFuelCost?.message}
+              />
+            </div>
+          )}
+        </div>
+        <div>
+          <Checkbox label="Jag har månadskort i kollektivtrafiken" {...register("transport.hasTransitCard")}
+            checked={hasTransit} />
+          {hasTransit && (
+            <div className="mt-4">
+              <label htmlFor="monthlyTransitCost" className="block text-sm font-medium">
+                Kostnad för månadskort
+              </label>
+              <FormattedNumberInput
+                id="monthlyTransitCost"
+                value={watch("transport.monthlyTransitCost") ?? 0}
+                onValueChange={(val) => setValue("transport.monthlyTransitCost", val ?? 0)}
+                placeholder="t.ex. 900 kr"
+                name={transitReg.name}
+                onBlur={transitReg.onBlur}
+                error={errors.transport?.monthlyTransitCost?.message}
+              />
+            </div>
+          )}
+        </div>
+      </div>
+    </OptionContainer>
   );
 };
 
 export default SubStepTransport;
+

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/StepBudgetExpenditureContainer.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/StepBudgetExpenditureContainer.tsx
@@ -25,6 +25,7 @@ import SubStepRent  from '@components/organisms/overlays/wizard/steps/StepBudget
 
 import SubStepFood  from '@components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/3_SubStepFood/SubStepFood';
 import SubStepFixedExp from '@components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/4_SubStepFixedExpenses/SubStepFixedExpenses';
+import SubStepTransport from '@components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/SubStepTransport';
 
 import LoadingScreen from '@components/molecules/feedback/LoadingScreen';
 
@@ -204,6 +205,7 @@ const StepBudgetExpenditureContainer = forwardRef<
       case 2: return <SubStepRent />;
       case 3: return <SubStepFood />;
       case 4: return <SubStepFixedExp />;
+      case 5: return <SubStepTransport />;
       // Add more cases for other sub-steps as needed
       default:return <div>All sub-steps complete!</div>;
     }

--- a/Frontend/src/hooks/wizard/useSaveStepData.tsx
+++ b/Frontend/src/hooks/wizard/useSaveStepData.tsx
@@ -32,6 +32,8 @@ function getPartialData<T extends ExpenditureFormValues>(
       return { food: allData.food } as Partial<T>;
     case 4:
       return { fixedExpenses: allData.fixedExpenses } as Partial<T>;
+    case 5:
+      return { transport: allData.transport } as Partial<T>;
     default:
       return {};
   }

--- a/Frontend/src/schemas/wizard/step2Schema.ts
+++ b/Frontend/src/schemas/wizard/step2Schema.ts
@@ -3,6 +3,7 @@ import { rentSchema }        from "./rentSchema";
 import { foodSchema }        from "./foodSchema";
 import { utilitiesSchema }   from "./utilitiesSchema";
 import { fixedExpensesSchema } from "./fixedExpensesSchema";
+import { transportSchema }   from "./transportSchema";
 
 // Step 2 schema for the wizard, which includes rent, food, utilities, and fixed expenses
 export const step2Schema = yup.object({
@@ -10,6 +11,7 @@ export const step2Schema = yup.object({
   food         : foodSchema,
   utilities    : utilitiesSchema,
   fixedExpenses: fixedExpensesSchema,
+  transport    : transportSchema,
 });
 
 /* infer the correct TS interface from the schema */

--- a/Frontend/src/schemas/wizard/transportSchema.ts
+++ b/Frontend/src/schemas/wizard/transportSchema.ts
@@ -1,0 +1,19 @@
+import * as yup from "yup";
+
+export const transportSchema = yup.object().shape({
+  hasCar: yup.boolean().default(false),
+  monthlyFuelCost: yup
+    .number()
+    .typeError("Måste vara ett nummer.")
+    .min(0, "Kostnad kan inte vara negativ.")
+    .nullable()
+    .default(0),
+  hasTransitCard: yup.boolean().default(false),
+  monthlyTransitCost: yup
+    .number()
+    .typeError("Måste vara ett nummer.")
+    .min(0, "Kostnad kan inte vara negativ.")
+    .nullable()
+    .default(0),
+});
+

--- a/Frontend/src/schemas/wizard/wizardRootSchema.ts
+++ b/Frontend/src/schemas/wizard/wizardRootSchema.ts
@@ -3,7 +3,8 @@ import { rentSchema } from "./rentSchema";
 import { utilitiesSchema } from "./utilitiesSchema";
 import { foodSchema } from "./foodSchema";
 import { incomeStepSchema } from "./incomeStepSchema";
-import { fixedExpensesSchema } from './fixedExpensesSchema'; 
+import { fixedExpensesSchema } from './fixedExpensesSchema';
+import { transportSchema } from './transportSchema';
 
 export const wizardRootSchema = yup.object().shape({
   // Step 1: Income schema
@@ -13,5 +14,6 @@ export const wizardRootSchema = yup.object().shape({
   food: foodSchema,
   utilities: utilitiesSchema,
   fixedExpenses: fixedExpensesSchema,
+  transport: transportSchema,
   // Add other sub-schemas here, e.g., expenditures: expendituresSchema
 });

--- a/Frontend/src/stores/Wizard/wizardDataStore.ts
+++ b/Frontend/src/stores/Wizard/wizardDataStore.ts
@@ -43,6 +43,12 @@ const initialWizardDataState: WizardData = {
       unionFees: null,
       customExpenses: [],
     },
+    transport: {
+      hasCar: false,
+      monthlyFuelCost: 0,
+      hasTransitCard: false,
+      monthlyTransitCost: 0,
+    },
     // Todo: For consistency, we should also define the structure for rent, food, and utilities.
   },
 };

--- a/Frontend/src/types/Wizard/ExpenditureFormValues.ts
+++ b/Frontend/src/types/Wizard/ExpenditureFormValues.ts
@@ -21,4 +21,10 @@ export interface ExpenditureFormValues extends FieldValues {
     water: number | null;
   };
   fixedExpenses?: FixedExpensesSubForm;
+  transport: {
+    hasCar: boolean;
+    monthlyFuelCost: number | null;
+    hasTransitCard: boolean;
+    monthlyTransitCost: number | null;
+  };
 }

--- a/Frontend/src/utils/ensureStep2Defaults.ts
+++ b/Frontend/src/utils/ensureStep2Defaults.ts
@@ -42,5 +42,13 @@ export function ensureStep2Defaults(
           fee : e?.fee ?? null,
         })) ?? [],
     },
+
+    /* ---------- transport ---------- */
+    transport: {
+      hasCar           : src?.transport?.hasCar            ?? false,
+      monthlyFuelCost  : src?.transport?.monthlyFuelCost   ?? 0,
+      hasTransitCard   : src?.transport?.hasTransitCard    ?? false,
+      monthlyTransitCost: src?.transport?.monthlyTransitCost ?? 0,
+    },
   };
 }


### PR DESCRIPTION
## Summary
- add transportation schema and defaults
- extend root wizard schemas and store
- implement transport substep with car and transit inputs
- wire new substep into wizard container and save logic

## Testing
- `npm test` *(fails: Could not locate module in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68466e9af61c832e92990bd3e56f9d39