### PR TITLE
Implement scroll to first error across wizard

### DIFF
--- a/Frontend/src/components/organisms/overlays/wizard/SetupWizard.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/SetupWizard.tsx
@@ -31,6 +31,8 @@ import useSaveWizardStep from "@hooks/wizard/useSaveWizardStep";
 import useWizardInit from "@hooks/wizard/useWizardInit";
 import useMediaQuery from "@hooks/useMediaQuery";
 import useWizardNavigation from "@hooks/wizard/useWizardNavigation";
+import useScrollToFirstError from "@/hooks/useScrollToFirstError";
+import { FieldErrors } from "react-hook-form";
 //local display state
 import useBudgetInfoDisplayFlags from "@hooks/wizard/flagHooks/useBudgetInfoDisplayFlags";
 // Header import
@@ -189,6 +191,11 @@ const SetupWizard: React.FC<SetupWizardProps> = ({ onClose }) => {
       setActiveStepRef(refObject.current);
     }
   }, [step, stepRefs[step]]);
+
+  // Scroll to the first error in whichever step is active
+  useScrollToFirstError(
+    (activeStepRef?.getErrors?.() as FieldErrors<any>) || {}
+  );
 
     /* -----------------------------------------------------------
     7. Ask the active child step (if any) for its sub-nav API

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/2_SubStepRent/SubStepRent.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/2_SubStepRent/SubStepRent.tsx
@@ -3,6 +3,7 @@ import { useFormContext, Controller, FieldPath } from "react-hook-form";
 import SelectDropdown from "@components/atoms/dropdown/SelectDropdown"; 
 import HomeTypeOption from "@/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/2_SubStepRent/components/HomeTypeOption";
 import { idFromPath } from "@/utils/idFromPath"; // 👈 Import the utility
+import useScrollToFirstError from "@/hooks/useScrollToFirstError";
 
 interface RentForm {
   rent: {
@@ -20,7 +21,10 @@ interface RentForm {
 const SubStepRent: React.FC = () => {
   const {
     control,
+    formState: { errors },
   } = useFormContext<RentForm>();
+
+  useScrollToFirstError(errors);
        
   return (
     <div className="relative w-full max-w-md mx-auto mt-4 p-4">

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/3_SubStepFood/SubStepFood.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/3_SubStepFood/SubStepFood.tsx
@@ -11,6 +11,7 @@ import HelpSection from "@components/molecules/helptexts/HelpSection";
 
 // hooks
 import { usePrevious } from "@hooks/usePrevious";
+import useScrollToFirstError from "@/hooks/useScrollToFirstError";
 // css module
 import styles from "./Styling/SubStepFood.module.css";
 // icons
@@ -31,6 +32,8 @@ const SubStepFood: React.FC = () => {
     setValue,
     formState: { errors },
   } = useFormContext<FoodForm>();
+
+  useScrollToFirstError(errors);
 
   // Ref for the Food Store Expenses container
   const foodStoreRef = useRef<HTMLDivElement>(null);

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/4_SubStepFixedExpenses/SubStepFixedExpenses.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/4_SubStepFixedExpenses/SubStepFixedExpenses.tsx
@@ -13,6 +13,7 @@ import GlossyFlipCard from "@components/molecules/cards/GlossyFlipCard/GlossyFli
 import FlipCardText from "@components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/text/FlipCardText";
 import useMediaQuery from '@hooks/useMediaQuery';
 import { idFromPath } from "@/utils/idFromPath";
+import useScrollToFirstError from "@/hooks/useScrollToFirstError";
 
 
 export interface FixedExpenseItem {
@@ -40,6 +41,8 @@ const SubStepFixedExpenses: React.FC = () => {
     clearErrors,
     formState: { errors, submitCount },
   } = useFormContext<{ fixedExpenses: FixedExpensesSubForm }>();
+
+  useScrollToFirstError(errors);
   
   const [openAccordion, setOpenAccordion] = useState<string>("custom");
 

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/5_Transport/SubStepTransport.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/5_Transport/SubStepTransport.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useFormContext } from "react-hook-form";
+import useScrollToFirstError from "@/hooks/useScrollToFirstError";
 
 import OptionContainer from "@components/molecules/containers/OptionContainer";
 import GlossyFlipCard from "@components/molecules/cards/GlossyFlipCard/GlossyFlipCard";
@@ -17,7 +18,9 @@ interface TransportForm {
 }
 
 const SubStepTransport: React.FC = () => {
-  useFormContext<TransportForm>();
+  const { formState: { errors } } = useFormContext<TransportForm>();
+
+  useScrollToFirstError(errors);
 
   return (
     <OptionContainer>

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/6_SubStepClothing/SubStepClothing.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/6_SubStepClothing/SubStepClothing.tsx
@@ -9,6 +9,7 @@ import FlipCardText from "@components/organisms/overlays/wizard/steps/StepBudget
 import FormattedNumberInput from "@components/atoms/InputField/FormattedNumberInput";
 import HelpSection from "@components/molecules/helptexts/HelpSection";
 import { idFromPath } from "@/utils/idFromPath";
+import useScrollToFirstError from "@/hooks/useScrollToFirstError";
 
 interface ClothingForm {
   clothing: {
@@ -25,6 +26,8 @@ const SubStepClothing: React.FC = () => {
     setValue,
     formState: { errors },
   } = useFormContext<ClothingForm>();
+
+  useScrollToFirstError(errors);
 
   const fieldPath = "clothing.monthlyClothingCost";
   const inputId = idFromPath(fieldPath);

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetIncome1/StepBudgetIncome.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetIncome1/StepBudgetIncome.tsx
@@ -16,6 +16,7 @@ import AcceptButton from "@components/atoms/buttons/AcceptButton";
 import coinsAnimation from "@assets/lottie/coins.json";
 import useYearlyIncome from "@hooks/wizard/useYearlyIncome";
 import { useToast } from "@context/ToastContext";
+import useScrollToFirstError from "@/hooks/useScrollToFirstError";
 import LoadingScreen from "@components/molecules/feedback/LoadingScreen";
 import DataTransparencySection from "@components/organisms/overlays/wizard/SharedComponents/Pages/DataTransparencySection";
 import HelpSectionDark from "@components/molecules/helptexts/HelpSectionDark";
@@ -51,6 +52,9 @@ const {
   control, watch, setValue, getValues,
   formState: { errors },
 } = useFormContext<IncomeFormValues>();
+
+  // Scroll to the first validation error when present
+  useScrollToFirstError(errors);
 
 
 

--- a/Frontend/src/hooks/wizard/useSaveStepData.tsx
+++ b/Frontend/src/hooks/wizard/useSaveStepData.tsx
@@ -103,6 +103,7 @@ export function useSaveStepData<T extends ExpenditureFormValues>({
         console.error('Error saving step data:', err);
         onError?.();
         saveQueue.enqueue({ stepNumber, subStepNumber: stepLeaving, data: part, goingBackwards });
+        return false;
       }
 
       setCurrentStep(stepGoing);


### PR DESCRIPTION
## Summary
- hook up `useScrollToFirstError` throughout the wizard
- ensure form pages and sub steps use the new hook
- stop navigation on API failure in `useSaveStepData`

## Testing
- `dotnet test --no-build` *(fails: command not found)*
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a8f5b2130832e96248999ca1dd5b9