### PR TITLE
Centralize scroll handling in wizard

### DIFF
--- a/Frontend/src/components/organisms/overlays/wizard/SetupWizard.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/SetupWizard.tsx
@@ -192,6 +192,11 @@ const SetupWizard: React.FC<SetupWizardProps> = ({ onClose }) => {
     }
   }, [step, stepRefs[step]]);
 
+  // Scroll to top whenever the major step changes
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }, [step]);
+
   // Scroll to the first error in whichever step is active
   useScrollToFirstError(
     (activeStepRef?.getErrors?.() as FieldErrors<any>) || {}

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/2_SubStepRent/SubStepRent.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/2_SubStepRent/SubStepRent.tsx
@@ -3,7 +3,6 @@ import { useFormContext, Controller, FieldPath } from "react-hook-form";
 import SelectDropdown from "@components/atoms/dropdown/SelectDropdown"; 
 import HomeTypeOption from "@/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/2_SubStepRent/components/HomeTypeOption";
 import { idFromPath } from "@/utils/idFromPath"; // 👈 Import the utility
-import useScrollToFirstError from "@/hooks/useScrollToFirstError";
 
 interface RentForm {
   rent: {
@@ -23,8 +22,6 @@ const SubStepRent: React.FC = () => {
     control,
     formState: { errors },
   } = useFormContext<RentForm>();
-
-  useScrollToFirstError(errors);
        
   return (
     <div className="relative w-full max-w-md mx-auto mt-4 p-4">

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/3_SubStepFood/SubStepFood.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/3_SubStepFood/SubStepFood.tsx
@@ -11,7 +11,6 @@ import HelpSection from "@components/molecules/helptexts/HelpSection";
 
 // hooks
 import { usePrevious } from "@hooks/usePrevious";
-import useScrollToFirstError from "@/hooks/useScrollToFirstError";
 // css module
 import styles from "./Styling/SubStepFood.module.css";
 // icons
@@ -32,8 +31,6 @@ const SubStepFood: React.FC = () => {
     setValue,
     formState: { errors },
   } = useFormContext<FoodForm>();
-
-  useScrollToFirstError(errors);
 
   // Ref for the Food Store Expenses container
   const foodStoreRef = useRef<HTMLDivElement>(null);

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/4_SubStepFixedExpenses/SubStepFixedExpenses.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/4_SubStepFixedExpenses/SubStepFixedExpenses.tsx
@@ -12,7 +12,6 @@ import GlossyFlipCard from "@components/molecules/cards/GlossyFlipCard/GlossyFli
 import FlipCardText from "@components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/text/FlipCardText";
 import useMediaQuery from '@hooks/useMediaQuery';
 import { idFromPath } from "@/utils/idFromPath";
-import useScrollToFirstError from "@/hooks/useScrollToFirstError";
 import CustomItemRow from "@components/organisms/overlays/wizard/SharedComponents/InputRows/CustomItemRow";
 
 
@@ -42,8 +41,6 @@ const SubStepFixedExpenses: React.FC = () => {
     formState: { errors, submitCount },
   } = useFormContext<{ fixedExpenses: FixedExpensesSubForm }>();
 
-  useScrollToFirstError(errors);
-  
   const [openAccordion, setOpenAccordion] = useState<string>("custom");
 
   const { fields, append, remove } = useFieldArray({

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/5_SubStepTransport/SubStepTransport.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/5_SubStepTransport/SubStepTransport.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useFormContext } from "react-hook-form";
-import useScrollToFirstError from "@/hooks/useScrollToFirstError";
 
 import OptionContainer from "@components/molecules/containers/OptionContainer";
 import GlossyFlipCard from "@components/molecules/cards/GlossyFlipCard/GlossyFlipCard";
@@ -19,8 +18,6 @@ interface TransportForm {
 
 const SubStepTransport: React.FC = () => {
   const { formState: { errors } } = useFormContext<TransportForm>();
-
-  useScrollToFirstError(errors);
 
   return (
     <OptionContainer>

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/6_SubStepClothing/SubStepClothing.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/6_SubStepClothing/SubStepClothing.tsx
@@ -9,7 +9,6 @@ import FlipCardText from "@components/organisms/overlays/wizard/steps/StepBudget
 import FormattedNumberInput from "@components/atoms/InputField/FormattedNumberInput";
 import HelpSection from "@components/molecules/helptexts/HelpSection";
 import { idFromPath } from "@/utils/idFromPath";
-import useScrollToFirstError from "@/hooks/useScrollToFirstError";
 
 interface ClothingForm {
   clothing: {
@@ -27,8 +26,6 @@ const SubStepClothing: React.FC = () => {
     register,
     formState: { errors },
   } = useFormContext<ClothingForm>();
-
-  useScrollToFirstError(errors);
 
   const fieldPath = "clothing.monthlyClothingCost";
   const inputId = idFromPath(fieldPath);

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/7_SubStepSubscriptions/SubStepSubscriptions.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/7_SubStepSubscriptions/SubStepSubscriptions.tsx
@@ -13,7 +13,6 @@ import CustomItemRow from "@components/organisms/overlays/wizard/SharedComponent
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Separator } from "@/components/ui/separator";
 import useMediaQuery from "@hooks/useMediaQuery";
-import useScrollToFirstError from "@/hooks/useScrollToFirstError";
 import { idFromPath } from "@/utils/idFromPath";
 
 export interface SubscriptionItem {
@@ -48,8 +47,6 @@ const SubStepSubscriptions: React.FC = () => {
     clearErrors,
     formState: { errors },
   } = useFormContext<{ subscriptions: SubscriptionsSubForm }>();
-
-  useScrollToFirstError(errors);
 
   const { fields, append, remove } = useFieldArray({
     control,

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/StepBudgetExpenditureContainer.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/StepBudgetExpenditureContainer.tsx
@@ -176,6 +176,11 @@ const StepBudgetExpenditureContainer = forwardRef<
   /* 6 ─── notify parent of sub-step -------------------------------- */
   useEffect(() => props.onSubStepChange?.(currentSub), [currentSub]);
 
+  // Scroll to top whenever a sub-step changes
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }, [currentSub]);
+
   /* 7 ─── imperative API ------------------------------------------- */
   useImperativeHandle(ref, () => ({
     validateFields: () => formMethods?.trigger() ?? Promise.resolve(false),

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/wrapper/WizardFormWrapperStep2.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/wrapper/WizardFormWrapperStep2.tsx
@@ -10,7 +10,6 @@ import { yupResolver } from "@hookform/resolvers/yup";
 import { step2Schema, Step2FormValues } from "@/schemas/wizard/step2Schema";
 import { useWizardDataStore } from "@/stores/Wizard/wizardDataStore";
 import { ensureStep2Defaults } from "@/utils/ensureStep2Defaults";
-import useScrollToFirstError from "@/hooks/useScrollToFirstError";
 
 /* ───────────────── Types exposed to parent ───────────────── */
 export interface WizardFormWrapperStep2Ref {
@@ -45,8 +44,6 @@ const WizardFormWrapperStep2 = forwardRef<
     mode: "onBlur",
     reValidateMode: "onChange",
   });
-   const { formState: { errors } } = methods;
-  useScrollToFirstError(errors);         
   /* 4.  Hydrate once if store updates later */
   const hydrated = useRef(false);
 

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetIncome1/StepBudgetIncome.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetIncome1/StepBudgetIncome.tsx
@@ -16,7 +16,6 @@ import AcceptButton from "@components/atoms/buttons/AcceptButton";
 import coinsAnimation from "@assets/lottie/coins.json";
 import useYearlyIncome from "@hooks/wizard/useYearlyIncome";
 import { useToast } from "@context/ToastContext";
-import useScrollToFirstError from "@/hooks/useScrollToFirstError";
 import LoadingScreen from "@components/molecules/feedback/LoadingScreen";
 import DataTransparencySection from "@components/organisms/overlays/wizard/SharedComponents/Pages/DataTransparencySection";
 import HelpSectionDark from "@components/molecules/helptexts/HelpSectionDark";
@@ -53,8 +52,6 @@ const {
   formState: { errors },
 } = useFormContext<IncomeFormValues>();
 
-  // Scroll to the first validation error when present
-  useScrollToFirstError(errors);
 
 
 

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetIncome1/wrapper/WizardFormWrapperStep1.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetIncome1/wrapper/WizardFormWrapperStep1.tsx
@@ -22,7 +22,6 @@ import { shallow } from 'zustand/shallow';
 import { useWizardDataStore, WizardDataStore } from '@/stores/Wizard/wizardDataStore';
 import { IncomeFormValues } from '@myTypes/Wizard/IncomeFormValues';
 import { incomeStepSchema } from '@schemas/wizard/incomeStepSchema';
-import useScrollToFirstError from '@/hooks/useScrollToFirstError'; 
 
 export interface WizardFormWrapperStep1Ref {
   validateFields: () => Promise<boolean>;
@@ -62,8 +61,6 @@ const WizardFormWrapperStep1 = forwardRef<
 
   const { control, watch, reset, getValues, formState, trigger, setFocus } = methods;
 
-  // 👇 Use the centralized hook with the form's errors
-  useScrollToFirstError(formState.errors);
 
   useEffect(() => {
     const subscription = watch(


### PR DESCRIPTION
## Summary
- remove per-form uses of `useScrollToFirstError`
- keep single invocation in `SetupWizard`
- ensure wizard scrolls to top when major step or sub-step changes

## Testing
- `npm -C Frontend test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fc7a93424832ebc9bb766dc6c885b