### PR TITLE
refactor(wizard): Unify navigation logic and streamline validation

### DIFF
--- a/Frontend/src/components/molecules/progress/StepCarousel.tsx
+++ b/Frontend/src/components/molecules/progress/StepCarousel.tsx
@@ -4,8 +4,8 @@ import { motion, AnimatePresence } from 'framer-motion';
 interface StepCarouselProps {
   steps: { icon: React.FC<React.SVGProps<SVGSVGElement>>; label: string }[];
   currentStep: number;
-  onStepClick: (step: number) => void;
-  visibleSteps?: number; 
+  onStepClick?: (step: number) => void;
+  visibleSteps?: number;
 }
 
 const StepCarousel: React.FC<StepCarouselProps> = ({
@@ -14,20 +14,20 @@ const StepCarousel: React.FC<StepCarouselProps> = ({
   onStepClick,
   visibleSteps = 1,
 }) => {
-  // Helper to wrap index if we want circular navigation
-  const wrapIndex = (idx: number) => (idx + steps.length) % steps.length;
 
-  // Indices to display: current step plus neighbors
   const indicesToShow: number[] = [];
   for (let offset = -visibleSteps; offset <= visibleSteps; offset++) {
-    indicesToShow.push(wrapIndex(currentStep + offset));
-  }
+    const newIndex = currentStep + offset;
 
-  // Horizontal spacing between icons
+    if (newIndex >= 0 && newIndex < steps.length) {
+      indicesToShow.push(newIndex);
+    }
+  }
+  // --- END OF FIX ---
+
   const horizontalSpacing = 60;
 
   return (
-    // Increase container height so labels are visible; remove overflow-hidden if needed
     <div className="relative flex items-center justify-center w-full h-32">
       <AnimatePresence>
         {indicesToShow.map((stepIndex) => {
@@ -65,8 +65,10 @@ const StepCarousel: React.FC<StepCarouselProps> = ({
                 damping: 14,
                 mass: 0.6,
               }}
-              onClick={() => onStepClick(stepIndex)}
-              className={`absolute cursor-pointer flex flex-col items-center ${
+              onClick={() => onStepClick?.(stepIndex)}
+              className={`absolute flex flex-col items-center ${
+                onStepClick ? 'cursor-pointer' : 'cursor-default'
+              } ${
                 isCurrent ? 'text-green-500' : ''
               }`}
               style={{ width: 50, height: 50 }}
@@ -74,13 +76,13 @@ const StepCarousel: React.FC<StepCarouselProps> = ({
               <Icon className="w-12 h-12" />
               {isCurrent && (
                 <span
-                    title={steps[stepIndex].label}
-                    className="text-sm mt-0 pointer-events-none absolute top-full left-1/2 transform -translate-x-1/2 whitespace-normal text-center"
-                    style={{ maxWidth: '120px', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}
+                  title={steps[stepIndex].label}
+                  className="text-sm mt-0 pointer-events-none absolute top-full left-1/2 transform -translate-x-1/2 whitespace-normal text-center"
+                  style={{ maxWidth: '120px', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}
                 >
-                    {steps[stepIndex].label}
+                  {steps[stepIndex].label}
                 </span>
-                )}
+              )}
             </motion.div>
           );
         })}

--- a/Frontend/src/components/organisms/overlays/wizard/SetupWizard.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/SetupWizard.tsx
@@ -314,49 +314,29 @@ const SetupWizard: React.FC<SetupWizardProps> = ({ onClose }) => {
 
           </AnimatedContent>
 
-          {/* NAVIGATION BUTTONS (BOTTOM) */}
-          {isMobile ? (
-            <footer className="fixed bottom-0 inset-x-0 p-4 bg-white/30 rounded-xl backdrop-blur-lg shadow-lg">
-              <WizardNavigationFooter
-                /* major */
-                prevMajor={hookPrevStep}
-                nextMajor={hookNextStep}
-                hasPrevMajor={step > 0}
-                hasNextMajor={step < totalSteps}
-                /* sub  */
-                prevSub={subNav.prevSub}
-                nextSub={subNav.nextSub}
-                hasPrevSub={subNav.hasPrevSub}
-                hasNextSub={subNav.hasNextSub}
-                /* shared flags */
-                connectionError={connectionError}
-                initLoading={initLoading}
-                transitionLoading={transitionLoading}
-                isDebugMode={isDebugMode}
-                showShakeAnimation={showShakeAnimation}
-                isSaving={saving}
-                step={step}
-              />
-            </footer>
-            ) : (
-            /* desktop */
+          <div className="w-full max-w-4xl mx-auto">
             <div className="my-6 w-full flex items-center justify-between">
               <WizardNavPair
                 step={step}
-                prevStep={hookPrevStep}
-                nextStep={hookNextStep}
-                hasPrev={step > 0}
-                hasNext={step < totalSteps}
+                prevStep={subNav.hasPrevSub ? subNav.prevSub : hookPrevStep}
+                nextStep={subNav.hasNextSub ? subNav.nextSub : hookNextStep}
+                hasPrev={subNav.hasPrevSub || step > 0}
+                hasNext={subNav.hasNextSub || step < totalSteps}
+                
+                // --- SUPPLY THE NEW INTEL ---
+                hasPrevSub={subNav.hasPrevSub}
+                hasNextSub={subNav.hasNextSub}
+
+                // ... all other props ...
                 connectionError={connectionError}
                 initLoading={initLoading}
                 transitionLoading={transitionLoading}
                 isDebugMode={isDebugMode}
                 showShakeAnimation={showShakeAnimation}
                 isSaving={saving}
-                isMajor
               />
             </div>
-          )}
+          </div>
         </motion.div>
       </div>
       {/* Confirm Modal */}

--- a/Frontend/src/components/organisms/overlays/wizard/SharedComponents/Buttons/WizardNavPair.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/SharedComponents/Buttons/WizardNavPair.tsx
@@ -1,82 +1,76 @@
-/**
- * WizardNavPair – renders two buttons:
- *   • Major mode  : ⏪ ⏩
- *   • Sub-step mode: ‹ › (or “Start” › on first sub-step)
- * Desktop / tablet use one major pair + one sub pair in different places.
- */
-import React from "react";
-import clsx from "clsx";
-import { ChevronLeft, ChevronRight, Rewind, FastForward } from "lucide-react";
-import GhostIconButton from "@components/atoms/buttons/GhostIconButton";
+import React from 'react';
+import clsx from 'clsx';
+import { ChevronLeft, ChevronRight, Rewind, FastForward } from 'lucide-react';
+import GhostIconButton from '@components/atoms/buttons/GhostIconButton';
 
 export interface WizardNavPairProps {
   step: number;
   prevStep(): void;
   nextStep(): void;
-  hasPrev: boolean;   
+  hasPrev: boolean;
   hasNext: boolean;
+  
+  // --- NEW INTEL ---
+  // The component now needs to know the sub-step status specifically.
+  hasPrevSub: boolean;
+  hasNextSub: boolean;
+
+  // ... other props are the same
   connectionError: boolean;
   initLoading: boolean;
   transitionLoading: boolean;
   isDebugMode: boolean;
   showShakeAnimation: boolean;
-  /** true = ⏪⏩  |  false = ‹ › / “Start” › */
-  isMajor: boolean;       
   isSaving: boolean;
 }
 
-const WizardNavPair: React.FC<WizardNavPairProps > = ({
+const WizardNavPair: React.FC<WizardNavPairProps> = ({
   step,
   prevStep,
   nextStep,
   hasPrev,
   hasNext,
+  // De-structure the new props
+  hasPrevSub,
+  hasNextSub,
   connectionError,
   initLoading,
   transitionLoading,
   isDebugMode,
   showShakeAnimation,
-  isMajor,
   isSaving,
 }) => {
-  
-  /* locks all buttons during async work */
-const isLocked =
-  isSaving ||                             // always locked when saving
-  (!isDebugMode && (                     // when *not* in debug…
-    initLoading ||                       // …if still initializing
-    transitionLoading ||                 // …or mid-transition
-    (connectionError && step === 0)      // …or on step 0 with a connection error
-  ));
+  const isLocked =
+    isSaving ||
+    (!isDebugMode && (
+      initLoading ||
+      transitionLoading ||
+      (connectionError && step === 0)
+    ));
 
-  /* decide per-button */
   const disablePrev = isLocked || !hasPrev;
   const disableNext = isLocked || !hasNext;
 
-  const btnClass = (disabled: boolean) =>
-      clsx(
-        disabled && "opacity-50 cursor-not-allowed"
-      );
-  const sizeClass = "w-12 h-12 md:w-14 md:h-14";          // or props.sizeClass
+  // --- THE REAL FIX: One brain for each button! ---
+  const isPrevMajor = !hasPrevSub; // If there's no sub-step to go back to, it's a major step back.
+  const isNextMajor = !hasNextSub; // If there's no sub-step to go forward to, it's a major step forward.
 
-  const hoverClass =
-  !showShakeAnimation && "hover:bg-customBlue2 hover:scale-105 transition-transform duration-150";
+  const IconPrev = isPrevMajor ? Rewind : ChevronLeft;
+  const IconNext = isNextMajor ? FastForward : ChevronRight;
 
-  //Lämnade här! När vi kollar connectionerror är det viktigt att vi också bara kollar i första steget, annars kommer inte användare komma vidare i guiden.
-  const IconPrev = isMajor ? Rewind : ChevronLeft;
-  const IconNext = isMajor ? FastForward : ChevronRight;
+  const labelPrev = isPrevMajor
+    ? 'Föregående huvudsteg'
+    : 'Föregående delsteg';
 
-  const labelPrev = isMajor
-    ? "Föregående huvudsteg"
-    : "Föregående delsteg";
+  const labelNext = isNextMajor
+    ? 'Nästa huvudsteg'
+    : 'Nästa delsteg';
 
-  /* sub-step pair shows “Starta” only on its first page (= no prev)  */
-  const labelNext = isMajor
-    ? "Nästa huvudsteg"
-    : !hasPrev                     // first sub-step
-    ? "Starta"
-    : "Nästa delsteg";
-
+  // ... the rest of the component is mostly the same ...
+  const btnClass = (disabled: boolean) => clsx(disabled && 'opacity-50 cursor-not-allowed');
+  const sizeClass = 'w-12 h-12 md:w-14 md:h-14';
+  const hoverClass = !showShakeAnimation && 'hover:bg-customBlue2 hover:scale-105 transition-transform duration-150';
+  
   return (
     <>
       <GhostIconButton

--- a/Frontend/src/components/organisms/overlays/wizard/SharedComponents/Menu/WizardProgress.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/SharedComponents/Menu/WizardProgress.tsx
@@ -1,5 +1,6 @@
-import React from "react";
-import { motion } from "framer-motion";
+import React from 'react';
+import { motion } from 'framer-motion';
+import clsx from 'clsx'; // I'm adding clsx for cleaner classes. If you don't have it, you can use template literals.
 
 interface WizardStep {
   icon: React.ComponentType<{ size: string | number | undefined }>;
@@ -22,6 +23,9 @@ const WizardProgress: React.FC<WizardProgressProps> = ({
   adjustProgress = false,
 }) => {
   const adjustmentValue = adjustProgress ? -5 : -12;
+  
+  // If we're in development mode, we allow clicking the steps.
+  const isDevMode = process.env.NODE_ENV === 'development';
 
   return (
     <div className="relative flex items-center justify-between mb-6">
@@ -29,9 +33,9 @@ const WizardProgress: React.FC<WizardProgressProps> = ({
       <div className="absolute top-1/2 left-0 w-full h-1 bg-gray-300 z-0 transform -translate-y-1/2">
         <motion.div
           className="h-full bg-darkLimeGreen"
-          initial={{ width: "0%" }}
+          initial={{ width: '0%' }}
           animate={{
-            width: step > 0 ? `${(step / totalSteps) * 100 + adjustmentValue}%` : "0%",
+            width: step > 0 ? `${(step / totalSteps) * 100 + adjustmentValue}%` : '0%',
           }}
           transition={{ duration: 0.3 }}
         />
@@ -41,30 +45,31 @@ const WizardProgress: React.FC<WizardProgressProps> = ({
       {steps.map((item, index) => {
         const currentStepIndex = index + 1;
         const isActive = step === currentStepIndex;
-
-        // Dynamically set the icon size. Magnify the active one!
         const iconSize = isActive ? 32 : 16;
 
         return (
           <button
             type="button"
             key={index}
-            onClick={() => onStepClick(currentStepIndex)}
-            className="relative z-10 flex flex-col items-center w-1/4 focus:outline-none"
+            // If we are in dev mode, the click handler works. Otherwise, it does nothing.
+            onClick={isDevMode ? () => onStepClick(currentStepIndex) : undefined}
+            // The button is disabled and looks disabled in production.
+            disabled={!isDevMode}
+            className={clsx(
+              'relative z-10 flex flex-col items-center w-1/4 focus:outline-none',
+              // If not in dev mode, it's not a pointer. It's a rock.
+              !isDevMode && 'cursor-not-allowed'
+            )}
           >
             <div
               className={`flex items-center justify-center w-10 h-10 rounded-full transition-all duration-300 ${
-                // 1. COMPLETED: Solid green background
                 step > currentStepIndex
-                  ? "bg-darkLimeGreen text-white"
-                // 2. CURRENT: "Glaslike" / "Magnifying Glass" style
-                : isActive
-                  ? "border-2 border-white/50 text-darkLimeGreen bg-white/20 backdrop-blur-sm transform scale-150 shadow-lg"
-                // 3. FUTURE: Neutral gray background
-                  : "bg-gray-300 text-gray-700"
+                  ? 'bg-darkLimeGreen text-white'
+                  : isActive
+                  ? 'border-2 border-white/50 text-darkLimeGreen bg-white/20 backdrop-blur-sm transform scale-150 shadow-lg'
+                  : 'bg-gray-300 text-gray-700'
               }`}
             >
-              {/* Use the dynamic iconSize here */}
               <item.icon size={iconSize} />
             </div>
             <span className="mt-2 text-sm font-medium text-gray-800">

--- a/Frontend/src/components/organisms/overlays/wizard/SharedComponents/Wrappers/WizardNavigationFooter.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/SharedComponents/Wrappers/WizardNavigationFooter.tsx
@@ -1,28 +1,23 @@
 /**
- * WizardNavigationFooter – mobile-only row with four buttons
- * ordered ⏪ ‹ › ⏩ (prevMajor, prevSub, nextSub, nextMajor).
+ * WizardNavigationFooter – mobile-only row with TWO smart buttons.
+ * It combines major and sub-step navigation into a unified experience.
  * Use in a fixed <footer> on screens < md.
  */
-import React from "react";
-import clsx from "clsx";
-import { WizardNavPairProps } from "@components/organisms/overlays/wizard/SharedComponents/Buttons/WizardNavPair"; 
-import NavigationButton, { WizardNavIconProps } from "@components/organisms/overlays/wizard/SharedComponents/Buttons/WizardNavIcon";
+import React from 'react';
+import clsx from 'clsx';
+import NavigationButton from '@components/organisms/overlays/wizard/SharedComponents/Buttons/WizardNavIcon';
 
+// Interface remains the same, we're just using the props differently
 export interface WizardNavigationFooterProps {
-  /* major-step handlers */
   prevMajor(): void;
   nextMajor(): void;
   hasPrevMajor: boolean;
   hasNextMajor: boolean;
-
-  /* sub-step handlers (optional if step has no sub-pages) */
   prevSub(): void;
   nextSub(): void;
   hasPrevSub: boolean;
   hasNextSub: boolean;
   isSaving: boolean;
-
-  /* shared flags */
   step: number;
   connectionError: boolean;
   initLoading: boolean;
@@ -32,71 +27,53 @@ export interface WizardNavigationFooterProps {
 }
 
 const WizardNavigationFooter: React.FC<WizardNavigationFooterProps> = ({
-  // handlers
   prevMajor, nextMajor, prevSub, nextSub,
-  // availability flags
   hasPrevMajor, hasNextMajor, hasPrevSub, hasNextSub,
-  // shared flags
   step, connectionError, initLoading, transitionLoading, isDebugMode, showShakeAnimation, isSaving,
 }) => {
-  // We hide sub-nav buttons if there are no sub-steps available.
-  const showSubNav = hasPrevSub || hasNextSub;
-  
   /* Lock the whole bar when requests / transitions are running */
   const isLocked =
-  isSaving ||                             // always locked when saving
-  (!isDebugMode && (                     // when *not* in debug…
-    initLoading ||                       // …if still initializing
-    transitionLoading ||                 // …or mid-transition
-    (connectionError && step === 0)      // …or on step 0 with a connection error
-  ));  
+    isSaving ||
+    (!isDebugMode && (
+      initLoading ||
+      transitionLoading ||
+      (connectionError && step === 0)
+    ));
 
-  /* One boolean per button */
-  const disablePrevMajor = isLocked || !hasPrevMajor;
-  const disablePrevSub   = isLocked || !hasPrevSub;
-  const disableNextSub   = isLocked || !hasNextSub;
-  const disableNextMajor = isLocked || !hasNextMajor;
+  // --- THE SMART LOGIC ---
+  // Determine the correct "Back" action and availability
+  const goBack = hasPrevSub ? prevSub : prevMajor;
+  const canGoBack = hasPrevSub || hasPrevMajor;
+  const disablePrev = isLocked || !canGoBack;
 
-  const isDisabled = isDebugMode && (connectionError || initLoading || transitionLoading);
+  // Determine the correct "Next" action and availability
+  const goNext = hasNextSub ? nextSub : nextMajor;
+  const canGoNext = hasNextSub || hasNextMajor;
+  const disableNext = isLocked || !canGoNext;
+
+  // Determine which icons to use
+  const prevIcon = hasPrevSub ? 'prevSub' : 'prevMajor';
+  const nextIcon = hasNextSub ? 'nextSub' : 'nextMajor';
+
   const btnCls = (disabled: boolean) =>
-    clsx(disabled && "opacity-50 cursor-not-allowed", showShakeAnimation && "motion-safe:animate-shake");
+    clsx(disabled && 'opacity-50 cursor-not-allowed', showShakeAnimation && 'motion-safe:animate-shake');
 
   return (
-    <div className="flex items-center justify-between w-full">
-      {/* 1 — Prev major (left) */}
+    <div className="flex items-center justify-between w-full px-4">
+      {/* 1 — The One "Back" Button */}
       <NavigationButton
-        variant="prevMajor"
-        onClick={prevMajor}
-        disabled={disablePrevMajor || isDisabled}
-        className={clsx(btnCls(disablePrevMajor), "w-12 h-12 md:w-14 md:h-14")}
+        variant={prevIcon}
+        onClick={goBack}
+        disabled={disablePrev}
+        className={clsx(btnCls(disablePrev), 'w-14 h-14')}
       />
 
-      {showSubNav && (
-        <div className="flex items-center space-x-16">
-          {/* 2 — Prev sub */}
-          <NavigationButton
-            variant="prevSub"
-            onClick={prevSub}
-            disabled={disablePrevSub || isDisabled}
-            className={clsx(btnCls(disablePrevSub), "w-12 h-12 md:w-14 md:h-14")}
-          />
-
-          {/* 3 — Next sub */}
-          <NavigationButton
-            variant="nextSub"
-            onClick={nextSub}
-            disabled={disableNextSub || isDisabled}
-            className={clsx(btnCls(disableNextSub), "w-12 h-12 md:w-14 md:h-14")}
-          />
-        </div>
-      )}
-
-      {/* 4 — Next major (right) */}
+      {/* 2 — The One "Next" Button */}
       <NavigationButton
-        variant="nextMajor"
-        onClick={nextMajor}
-        disabled={disableNextMajor  || isDisabled}
-        className={clsx(btnCls(disableNextMajor), "w-12 h-12 md:w-14 md:h-14")}
+        variant={nextIcon}
+        onClick={goNext}
+        disabled={disableNext}
+        className={clsx(btnCls(disableNext), 'w-14 h-14')}
       />
     </div>
   );

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/StepBudgetExpenditure.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/StepBudgetExpenditure.tsx
@@ -19,6 +19,7 @@ export interface StepBudgetExpenditureRef {
   hasPrevSub(): boolean;
   hasNextSub(): boolean;
   isSaving(): boolean;
+  hasSubSteps: () => boolean; 
 }
 
 interface StepBudgetExpenditureProps {
@@ -68,6 +69,7 @@ const StepBudgetExpenditure = forwardRef<
     hasPrevSub: () => containerRef.current?.hasPrevSub?.() ?? false,
     hasNextSub: () => containerRef.current?.hasNextSub?.() ?? false,
     isSaving: () => containerRef.current?.isSaving?.() ?? false,
+    hasSubSteps: () => true,
   }));
   const containerKey = "step-budget-expenditure-container";
   const getCurrentSubStep = () => {

--- a/Frontend/src/hooks/wizard/useWizardNavigation.ts
+++ b/Frontend/src/hooks/wizard/useWizardNavigation.ts
@@ -1,45 +1,34 @@
-import { useCallback } from "react";
-import { useToast } from "@context/ToastContext";
-import { handleStepValidation } from "@components/organisms/overlays/wizard/validation/handleStepValidation";
+import { useCallback } from 'react';
+import { useToast } from '@context/ToastContext';
+import { handleStepValidation } from '@components/organisms/overlays/wizard/validation/handleStepValidation';
 
-/* ------------------------------------------------------------------ */
-/* Hook props                                                         */
-/* ------------------------------------------------------------------ */
 interface UseWizardNavigationProps {
   step: number;
   setStep: React.Dispatch<React.SetStateAction<number>>;
   totalSteps: number;
-  /* refs to every major-step component (index == major-step) */
   stepRefs: Record<number, React.RefObject<any>>;
-  /* global UI-locks / spinners */
   setTransitionLoading(v: boolean): void;
-  /* local cache of form-snapshots */
   setCurrentStepState(
     v: React.SetStateAction<Record<number, { subStep: number; data: any }>>
   ): void;
-  /* server-side save supplied by parent */
   handleSaveStepData(
     stepNumber: number,
     subStep: number,
     data: any,
     goingBackwards: boolean
   ): Promise<boolean>;
-  /* wizard meta-data (last visited sub-step) */
   setWizardData(
     v: React.SetStateAction<
       Record<number, { lastVisitedSubStep?: number }>
     >
   ): void;
-  /* misc helpers */
   triggerShakeAnimation(duration?: number): void;
   isDebugMode: boolean;
   setShowSideIncome(v: boolean): void;
   setShowHouseholdMembers(v: boolean): void;
 }
 
-/* ------------------------------------------------------------------ */
-/* The hook                                                           */
-/* ------------------------------------------------------------------ */
+
 const useWizardNavigation = ({
   step,
   setStep,
@@ -56,97 +45,87 @@ const useWizardNavigation = ({
 }: UseWizardNavigationProps) => {
   const { showToast } = useToast();
 
-  /* ================================================================ */
-  /* One unified handler for both “next” and “prev”                   */
-  /* ================================================================ */
   const navigateStep = useCallback(
-    async (direction: "next" | "prev") => {
-      /* -------------------------------------------------------------- */
-      /* 1. Prep & collect info                                         */
-      /* -------------------------------------------------------------- */
+    async (direction: 'next' | 'prev') => {
       setTransitionLoading(true);
 
       const ref = stepRefs[step];
       const onRealStep = step > 0 && ref?.current;
-      const goingBack = direction === "prev";
+      const goingBack = direction === 'prev';
 
-      /* -------------------------------------------------------------- */
-      /* 2. Client-side validation (only when moving forward)           */
-      /* -------------------------------------------------------------- */
-      let validatedData: any | null = null; // Will hold our clean data on success
+      const isComplexStep = onRealStep && ref.current.hasSubSteps ? ref.current.hasSubSteps() : false;
+
+      let validatedData: any | null = null;
+
 
       if (!goingBack && onRealStep) {
-        // Call our updated validation function which returns clean data or null
-        validatedData = await handleStepValidation(
-          step,
-          stepRefs,
-          setShowSideIncome,
-          setShowHouseholdMembers
-        );
+        if (isComplexStep) {
 
-        // NEW: Check if it returned null (which signifies validation failure)
+          console.log(`DUKE'S ORDERS: Trusting complex step ${step}. Advancing without major validation.`);
+          validatedData = ref.current.getStepData();
+        } else {
+
+          console.log(`DUKE'S ORDERS: Validating simple step ${step}...`);
+          validatedData = await handleStepValidation(
+            step,
+            stepRefs,
+            setShowSideIncome,
+            setShowHouseholdMembers
+          );
+        }
+
+
         if (!validatedData) {
           triggerShakeAnimation();
           setTransitionLoading(false);
-          return;
+          return; // MISSION ABORTED. HOLD POSITION.
         }
       }
+      
 
-      /* -------------------------------------------------------------- */
-      /* 3. API save ( skip on step 0 )                                 */
-      /* -------------------------------------------------------------- */
+      /* 3. API save ( skip on step 0 ) */
       let saveSuccess = true;
       if (onRealStep) {
-        // NEW: Determine the correct data to save.
-        // If moving forward, use the clean data from our validation step.
-        // If going backward, get the raw data since validation was skipped.
+
         const dataToSave = goingBack ? ref.current.getStepData() : validatedData;
         const currentSub = ref.current.getCurrentSubStep?.() ?? 1;
 
         saveSuccess = await handleSaveStepData(
           step,
           currentSub,
-          dataToSave, // Use the corrected data object
+          dataToSave,
           goingBack
         );
 
-        /* Failed → keep user on page, keep old cache */
         if (!saveSuccess && !isDebugMode) {
           showToast(
-            "🚨 Ett fel uppstod – försök igen eller kontakta support.",
-            "error"
+            '🚨 Ett fel uppstod – försök igen eller kontakta support.',
+            'error'
           );
           setTransitionLoading(false);
           return;
         }
       }
 
-      /* -------------------------------------------------------------- */
-      /* 4. Update local caches *only* after successful save            */
-      /* -------------------------------------------------------------- */
+      /* 4. Update local caches *only* after successful save */
       if (onRealStep && saveSuccess) {
-        // NEW: Also use the clean/correct data for the local snapshot.
         const dataForCache = goingBack ? ref.current.getStepData() : validatedData;
         const currentSub = ref.current.getCurrentSubStep?.() ?? 1;
         
-        /* snapshot of the form */
         setCurrentStepState((prev) => ({
           ...prev,
           [step]: { subStep: currentSub, data: dataForCache },
         }));
 
-        /* remember last visited sub-step for each major-step */
         setWizardData((prev) => ({
           ...prev,
           [step]: { ...prev[step], lastVisitedSubStep: currentSub },
         }));
       }
 
-      /* -------------------------------------------------------------- */
-      /* 5. Finally change major-step index                             */
-      /* -------------------------------------------------------------- */
+
       setStep((prev) =>
-        direction === "next"
+        direction === 'next'
           ? Math.min(prev + 1, totalSteps)
           : Math.max(prev - 1, 0)
       );
@@ -170,9 +149,8 @@ const useWizardNavigation = ({
     ]
   );
 
-  /* public helpers */
-  const nextStep = useCallback(() => navigateStep("next"), [navigateStep]);
-  const prevStep = useCallback(() => navigateStep("prev"), [navigateStep]);
+  const nextStep = useCallback(() => navigateStep('next'), [navigateStep]);
+  const prevStep = useCallback(() => navigateStep('prev'), [navigateStep]);
 
   return { nextStep, prevStep };
 };


### PR DESCRIPTION
This commit introduces a significant refactor to the Setup Wizard's architecture to improve user experience, clarify state management, and enforce a more robust validation strategy.

The primary motivation was to resolve a disjointed navigation flow within steps that contain sub-steps, and to prevent redundant validation calls during major step transitions. Key Changes:

    Unified Navigation Controls:
        The separate major-step and sub-step navigation buttons have been consolidated into a single, context-aware pair of Next and Back buttons.
        These buttons now dynamically update their function and icon (> vs. >>) based on whether sub-steps remain (hasNextSub, hasPrevSub), creating a more intuitive, linear path for the user.
        All navigation UI has been removed from child step components and is now exclusively managed by the parent SetupWizard to enforce a single source of truth.

    Conditional Step Validation:
        A new method, hasSubSteps(), has been added to the step component's ref interface to allow the navigation logic to differentiate between simple and complex (multi-sub-step) wizard steps.
        The main useWizardNavigation hook now only triggers form validation (handleStepValidation) on a major step transition if the current step is simple. Complex steps, which handle their own incremental validation, are now trusted, preventing redundant validation checks.

    Production Hardening & Debug Features:
        The WizardProgress component is now disabled in production builds. It uses process.env.NODE_ENV to make the step indicators non-interactive, preventing users from skipping the intended wizard flow. The onStepClick functionality is preserved for debugging in development environments.

    Component & Type Refinements:
        Corrected several TypeScript errors by clarifying the distinction between a component's Props and its Ref interface, particularly for the hasSubSteps API.
        Modified the StepCarousel to support a read-only mode by making its onStepClick prop optional.
        Constrained the desktop navigation buttons within a max-width container to maintain visual cohesion with the form content on wider viewports.