### PR TITLE
Implement savings habits sub-step

### DIFF
--- a/Frontend/src/components/atoms/InputField/RangeSlider.tsx
+++ b/Frontend/src/components/atoms/InputField/RangeSlider.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+interface RangeSliderProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
+  value: number;
+  onChange: (value: number) => void;
+}
+
+const RangeSlider: React.FC<RangeSliderProps> = ({
+  value,
+  onChange,
+  min = 0,
+  max = 100,
+  step = 1,
+  className = '',
+  ...rest
+}) => (
+  <input
+    type="range"
+    min={min}
+    max={max}
+    step={step}
+    value={value}
+    onChange={(e) => onChange(Number(e.target.value))}
+    className={`w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer accent-limeGreen ${className}`}
+    {...rest}
+  />
+);
+
+export default RangeSlider;

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetSavings3/Components/Pages/SubSteps/2_SubStepHabits/SubStepHabits.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetSavings3/Components/Pages/SubSteps/2_SubStepHabits/SubStepHabits.tsx
@@ -1,10 +1,74 @@
 import React from 'react';
+import { useFormContext } from 'react-hook-form';
+import OptionContainer from '@components/molecules/containers/OptionContainer';
+import RangeSlider from '@components/atoms/InputField/RangeSlider';
+import SelectDropdown from '@components/atoms/dropdown/SelectDropdown';
+import { useWizardDataStore } from '@/stores/Wizard/wizardDataStore';
+import { Step3FormValues } from '@/schemas/wizard/step3Schema';
+import { calcMonthlyIncome } from '@/utils/wizard/wizardHelpers';
 
-const SubStepHabits: React.FC = () => (
-  <div className="p-4 text-white">
-    <h3 className="text-2xl font-bold text-darkLimeGreen mb-4 text-center">Nuvarande sparvanor</h3>
-    <p className="text-center">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque vitae velit ex.</p>
-  </div>
-);
+const SubStepHabits: React.FC = () => {
+  const { watch, setValue } = useFormContext<Step3FormValues>();
+  const income = useWizardDataStore((s) => s.data.income);
+  const maxIncome = calcMonthlyIncome(income);
+
+  const monthlySavings = watch('monthlySavings');
+  const savingMethod = watch('savingMethod');
+
+  return (
+    <OptionContainer>
+      <section className="max-w-xl mx-auto sm:px-6 lg:px-12 py-8 pb-safe space-y-8">
+        <header className="space-y-2 text-center">
+          <h3 className="text-2xl font-bold text-darkLimeGreen">
+            Great! To help us give you the best advice, you can tell us about your habits below.
+          </h3>
+          <p className="text-white">
+            This info helps us see if your goals are realistic with your current budget.
+          </p>
+        </header>
+
+        {/* Monthly Savings Slider */}
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-standardMenuColor/90 dark:text-standardMenuColor">
+            Roughly how much do you set aside for savings each month?
+          </label>
+          <div className="flex items-center gap-2">
+            <RangeSlider
+              min={0}
+              max={maxIncome}
+              value={monthlySavings ?? 0}
+              onChange={(val) => setValue('monthlySavings', val, { shouldValidate: false, shouldDirty: true })}
+              className="flex-1"
+            />
+            <span className="text-white w-16 text-right">
+              {(monthlySavings ?? 0).toLocaleString('sv-SE')} kr
+            </span>
+            <button
+              type="button"
+              onClick={() => setValue('monthlySavings', null, { shouldValidate: false, shouldDirty: true })}
+              className="ml-2 text-xs text-gray-300 underline whitespace-nowrap"
+            >
+              I prefer not to say
+            </button>
+          </div>
+        </div>
+
+        {/* Saving Method Dropdown */}
+        <SelectDropdown
+          label="How do you usually save?"
+          value={savingMethod ?? ''}
+          onChange={(e) => setValue('savingMethod', e.target.value, { shouldValidate: false, shouldDirty: true })}
+          options={[
+            { value: '', label: 'Select...', disabled: true },
+            { value: 'auto', label: 'Automatic transfer' },
+            { value: 'manual', label: 'Manual transfer' },
+            { value: 'invest', label: 'Investments' },
+            { value: 'prefer_not', label: 'Prefer not to say' },
+          ]}
+        />
+      </section>
+    </OptionContainer>
+  );
+};
 
 export default SubStepHabits;

--- a/Frontend/src/schemas/wizard/step3Schema.ts
+++ b/Frontend/src/schemas/wizard/step3Schema.ts
@@ -2,7 +2,8 @@ import * as yup from 'yup';
 
 export const step3Schema = yup.object({
   savingHabit: yup.string().required(),
-  currentSavings: yup.number().nullable(),
+  monthlySavings: yup.number().nullable(),
+  savingMethod: yup.string().nullable(),
   goals: yup.array(
     yup.object({
       id: yup.string().optional(),

--- a/Frontend/src/stores/Wizard/wizardDataStore.ts
+++ b/Frontend/src/stores/Wizard/wizardDataStore.ts
@@ -67,7 +67,8 @@ const initialWizardDataState: WizardData = {
   },
   savings: {
     savingHabit: '',
-    currentSavings: null,
+    monthlySavings: null,
+    savingMethod: '',
     goals: [],
   },
 };

--- a/Frontend/src/types/Wizard/SavingsFormValues.ts
+++ b/Frontend/src/types/Wizard/SavingsFormValues.ts
@@ -8,6 +8,7 @@ export interface SavingsGoal {
 
 export interface SavingsFormValues extends FieldValues {
   savingHabit: string;
-  currentSavings: number | null;
+  monthlySavings: number | null;
+  savingMethod: string | null;
   goals: SavingsGoal[];
 }


### PR DESCRIPTION
## Summary
- add optional monthly savings & saving method fields to step 3 schema and store
- include these fields in wizard types
- create RangeSlider input component
- implement SubStepHabits UI for current savings habits

## Testing
- `npm install` *(inside Frontend folder)*
- `npx tsc -p tsconfig.json` *(fails: cannot find modules in unrelated Registration.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_685556276e80832e91f694bc520c4a48