### PR TITLE
Implement savings goals substep

### DIFF
--- a/Frontend/src/components/atoms/InputField/CheckboxOption.tsx
+++ b/Frontend/src/components/atoms/InputField/CheckboxOption.tsx
@@ -1,0 +1,32 @@
+import React, { InputHTMLAttributes } from 'react';
+
+// Define the props for the component. It extends all standard input attributes
+// but requires 'id' and 'label' for the component to function correctly.
+interface CheckboxOptionProps extends InputHTMLAttributes<HTMLInputElement> {
+  id: string;
+  label: string;
+}
+
+/**
+ * A styled checkbox component with a label.
+ * It's designed as a self-contained unit with a surrounding label,
+ * making the entire area clickable.
+ */
+const CheckboxOption: React.FC<CheckboxOptionProps> = ({ id, label, ...props }) => {
+  return (
+    <label
+      htmlFor={id}
+      className="flex items-center space-x-3 p-3 bg-white/5 hover:bg-white/10 rounded-lg cursor-pointer transition-colors"
+    >
+      <input
+        id={id}
+        type="checkbox"
+        className="h-5 w-5 rounded border-gray-300 text-lime-500 focus:ring-lime-400 bg-transparent"
+        {...props} // Spreads other props like 'checked', 'onChange', 'value', etc.
+      />
+      <span className="text-white font-medium">{label}</span>
+    </label>
+  );
+};
+
+export default CheckboxOption;

--- a/Frontend/src/components/modals/GoalTemplateModal.tsx
+++ b/Frontend/src/components/modals/GoalTemplateModal.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { PiggyBank, Car, Home, Plane, X, PlusCircle } from 'lucide-react';
+import { goalTemplates } from './goalTemplates'; 
+
+interface GoalTemplateModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSelect: (template: any) => void;
+  onSelectBlank: () => void;
+}
+
+const iconMap = {
+  Buffert: <PiggyBank className="h-8 w-8 text-darkLimeGreen" />,
+  "Ny bil": <Car className="h-8 w-8 text-darkLimeGreen" />,
+  Kontantinsats: <Home className="h-8 w-8 text-darkLimeGreen" />,
+  "Resa till solen": <Plane className="h-8 w-8 text-darkLimeGreen" />,
+};
+
+export const GoalTemplateModal: React.FC<GoalTemplateModalProps> = ({ isOpen, onClose, onSelect, onSelectBlank }) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm">
+      <motion.div
+        initial={{ opacity: 0, scale: 0.9 }}
+        animate={{ opacity: 1, scale: 1 }}
+        exit={{ opacity: 0, scale: 0.9 }}
+        className="relative w-full max-w-2xl rounded-2xl bg-[#1a1a1a] p-8 border border-white/20"
+      >
+        <button
+          onClick={onClose}
+          className="absolute top-4 right-4 text-white/50 hover:text-white"
+          title="Stäng"
+          aria-label="Stäng"
+        >
+          <X size={24} />
+        </button>
+        <h3 className="text-2xl font-bold text-white mb-6">Välj en mall för ditt sparmål</h3>
+        
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {goalTemplates.map((template) => (
+            <button
+              key={template.name}
+              onClick={() => onSelect(template)}
+              className="p-6 rounded-xl bg-white/5 hover:bg-white/10 border border-white/10 text-left transition"
+            >
+              {iconMap[template.name]}
+              <h4 className="font-semibold text-white mt-3">{template.name}</h4>
+              <p className="text-sm text-white/60">{template.targetAmount.toLocaleString('sv-SE')} kr</p>
+            </button>
+          ))}
+
+          {/* And here's the option for the guy who knows his own mind. */}
+          <button
+            onClick={onSelectBlank}
+            className="p-6 rounded-xl bg-transparent hover:bg-white/10 border-2 border-dashed border-white/20 text-left transition flex flex-col items-center justify-center text-white/60 hover:text-white"
+          >
+            <PlusCircle size={32} />
+            <span className="font-semibold mt-3">Börja från noll</span>
+          </button>
+        </div>
+      </motion.div>
+    </div>
+  );
+};

--- a/Frontend/src/components/modals/goalTemplates.tsx
+++ b/Frontend/src/components/modals/goalTemplates.tsx
@@ -1,0 +1,44 @@
+export interface GoalTemplate {
+  name: "Resa till solen" | "Buffert" | "Ny bil" | "Kontantinsats";
+  targetAmount: number;
+  targetDate: string; // YYYY-MM-DD format
+}
+
+/**
+ * Our date specialist. Give him a number of years, he gives you back a
+ * perfect YYYY-MM-DD string for that many years in the future.
+ * Always fresh, never expired.
+ * @param yearsToAdd How many years to add to today's date.
+ * @returns A string like "2026-06-23"
+ */
+const getFutureDate = (yearsToAdd: number): string => {
+  const today = new Date();
+  today.setFullYear(today.getFullYear() + yearsToAdd);
+  // .toISOString() gives us "2026-06-23T10:00:00.000Z"
+  // We just clip the first 10 characters. 
+  return today.toISOString().slice(0, 10);
+};
+
+
+export const goalTemplates: GoalTemplate[] = [
+  { 
+    name: "Resa till solen", 
+    targetAmount: 25000, 
+    targetDate: getFutureDate(1) // Always 1 year from now.
+  },
+  { 
+    name: "Buffert", 
+    targetAmount: 50000, 
+    targetDate: getFutureDate(2) // Always 2 years from now.
+  },
+  { 
+    name: "Ny bil", 
+    targetAmount: 75000, 
+    targetDate: getFutureDate(3) // Always 3 years from now.
+  },
+  { 
+    name: "Kontantinsats", 
+    targetAmount: 150000, 
+    targetDate: getFutureDate(5) // The big one is always 5 years away.
+  },
+];

--- a/Frontend/src/components/molecules/InputField/EditableSavingsInput.tsx
+++ b/Frontend/src/components/molecules/InputField/EditableSavingsInput.tsx
@@ -1,0 +1,112 @@
+import React, { useState, useRef } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { Pencil } from "lucide-react";
+import RangeSlider from "@/components/atoms/InputField/RangeSlider";
+
+interface EditableSavingsInputProps {
+  value: number;
+  max: number;
+  onChange: (newValue: number) => void;
+  "aria-labelledby": string;
+}
+
+/**
+ * A component that displays a numeric value with a slider,
+ * and allows the user to click to edit the exact amount in a text input.
+ */
+const EditableSavingsInput: React.FC<EditableSavingsInputProps> = ({
+  value,
+  max,
+  onChange,
+  "aria-labelledby": ariaLabelledBy,
+}) => {
+  const [editing, setEditing] = useState(false);
+  const [showHint, setShowHint] = useState(true);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  // Commit the new value from the text input
+  const commit = () => {
+    const raw = Number(inputRef.current?.value ?? value ?? 0);
+    const clamped = Math.min(Math.max(raw, 0), max);
+    onChange(clamped);
+    setEditing(false);
+  };
+
+  // Cancel editing
+  const cancel = () => {
+    setEditing(false);
+  };
+
+  return (
+    <div className="space-y-4">
+      <RangeSlider
+        min={0}
+        max={max}
+        value={value}
+        onChange={onChange} // Pass the onChange handler directly to the slider
+        aria-labelledby={ariaLabelledBy}
+      />
+      <div className="flex flex-col items-center">
+        <AnimatePresence mode="wait" initial={false}>
+          {editing ? (
+            <motion.input
+              key="input"
+              ref={inputRef}
+              id="monthlySavingsInput" // This ID is used by the parent label
+              aria-label="Redigera månatligt sparbelopp, kronor"
+              title="Månatligt sparbelopp"
+              placeholder="0"
+              type="number"
+              min={0}
+              max={max}
+              step={100}
+              defaultValue={value}
+              onBlur={commit}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") commit();
+                if (e.key === "Escape") cancel();
+              }}
+              className="w-40 text-3xl leading-none bg-transparent text-center font-bold text-white outline-none border-b-2 border-limeGreen focus:border-darkLimeGreen tabular-nums"
+              initial={{ scale: 0.9, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              exit={{ scale: 0.9, opacity: 0 }}
+              autoFocus
+            />
+          ) : (
+            <motion.button
+              key="label"
+              type="button"
+              onClick={() => {
+                setEditing(true);
+                setShowHint(false);
+              }}
+              className="group flex items-center text-white/90 hover:text-limeGreen/95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-limeGreen rounded-md cursor-pointer"
+              initial={{ scale: 0.9, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              exit={{ scale: 0.9, opacity: 0 }}
+            >
+              <span className="text-3xl leading-none font-bold tabular-nums">
+                {value.toLocaleString("sv-SE")}
+              </span>
+              <span className="ml-1 text-lg leading-none font-semibold">kr</span>
+              <Pencil className="ml-2 w-6 h-6 opacity-60 group-hover:opacity-100 transition-opacity" />
+            </motion.button>
+          )}
+        </AnimatePresence>
+        {showHint && !editing && (
+          <motion.p
+            key="hint"
+            className="mt-1 text-xs text-gray-300/80"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ delay: 0.4 }}
+          >
+            Klicka för att redigera eller ange ett exakt belopp
+          </motion.p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default EditableSavingsInput;

--- a/Frontend/src/components/molecules/containers/GoalContainer.tsx
+++ b/Frontend/src/components/molecules/containers/GoalContainer.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { motion, MotionProps } from 'framer-motion';
+
+// We accept all the standard motion props to keep it flexible
+interface GoalContainerProps extends MotionProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+const GoalContainer: React.FC<GoalContainerProps> = ({ children, className, ...props }) => {
+  return (
+    <motion.div
+      
+      className={`relative overflow-hidden rounded-2xl border border-white/5 bg-slate-800/40 shadow-xl backdrop-blur-md ${className || ''}`}
+      {...props} // Pass through all the animation props
+    >
+      {/* The Signature Pinstripe */}
+      <div className="absolute inset-y-0 left-0 w-1 rounded-r-2xl bg-gradient-to-b from-darkLimeGreen to-green-500" aria-hidden />
+      
+      {/* The actual content goes here */}
+      {children}
+    </motion.div>
+  );
+};
+
+export default GoalContainer;

--- a/Frontend/src/components/molecules/containers/OptionContainer.tsx
+++ b/Frontend/src/components/molecules/containers/OptionContainer.tsx
@@ -1,12 +1,15 @@
 import React, { ReactNode } from 'react';
 
+
 interface OptionContainerProps {
   children: ReactNode;
+  className?: string; 
 }
 
-const OptionContainer: React.FC<OptionContainerProps> = ({ children }) => {
+const OptionContainer: React.FC<OptionContainerProps> = ({ children, className = "" }) => {
+
   return (
-    <div className="mt-4 p-4 bg-white/40 rounded-lg shadow-md text-gray-900">
+    <div className={`mt-4 bg-white/40 rounded-lg shadow-md text-gray-900 ${className}`}>
       {children}
     </div>
   );

--- a/Frontend/src/components/molecules/messaging/FormErrorSummary.tsx
+++ b/Frontend/src/components/molecules/messaging/FormErrorSummary.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { AlertTriangle } from "lucide-react";
+import { FieldErrors, FieldError } from "react-hook-form";
+
+// Define the props the component will accept
+interface FormErrorSummaryProps {
+  errors: FieldErrors;
+  // 'name' will be the key of the field array in the form, e.g., "goals"
+  name: string;
+}
+
+const FormErrorSummary: React.FC<FormErrorSummaryProps> = ({ errors, name }) => {
+  // Access the errors for the specific field array dynamically using the name prop
+  const fieldArrayErrors = errors[name];
+
+  // We only render if there are errors for this specific field array
+  if (!fieldArrayErrors || !Array.isArray(fieldArrayErrors)) {
+    return null;
+  }
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        initial={{ opacity: 0, y: -10 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: -10 }}
+        className="rounded-lg border border-red-500/50 bg-red-500/10 p-4"
+      >
+        <div className="flex items-center">
+          <AlertTriangle
+            className="mr-3 h-5 w-5 flex-shrink-0 text-red-700"
+            aria-hidden="true"
+          />
+          <h4 className="font-bold text-red-700">
+            Vänligen åtgärda felen nedan
+          </h4>
+        </div>
+        <ul className="mt-3 list-disc list-inside space-y-1 pl-8 text-sm text-red-600/90">
+          {fieldArrayErrors.map((goalError, index) => {
+            if (!goalError) return null; // Handles sparse error arrays
+
+            // This is the type-safe way to iterate through the nested errors
+            return Object.values(goalError).map((error) => {
+              // We add a type guard to ensure 'error' is a FieldError object
+              if (error && typeof error === 'object' && 'message' in error) {
+                return (
+                  <li key={`${index}-${(error as FieldError).message}`}>
+                    {(error as FieldError).message}
+                  </li>
+                );
+              }
+              return null;
+            });
+          })}
+        </ul>
+      </motion.div>
+    </AnimatePresence>
+  );
+};
+
+export default FormErrorSummary;

--- a/Frontend/src/components/molecules/messaging/InfoBox.tsx
+++ b/Frontend/src/components/molecules/messaging/InfoBox.tsx
@@ -1,0 +1,40 @@
+// In InfoBox.tsx
+
+import React from 'react';
+import { motion } from 'framer-motion';
+import { Info } from 'lucide-react';
+
+interface InfoBoxProps {
+  children: React.ReactNode;
+  className?: string;
+  icon?: boolean;
+}
+
+const InfoBox: React.FC<InfoBoxProps> = ({ children, className, icon = true }) => {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: -10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4, delay: 0.1 }}
+      className={`rounded-xl bg-slate-800/50 p-4 text-sm text-white/90 ring-1 ring-inset ring-white/10 ${className || ''}`}
+    >
+      {/* THE FIX:
+        This container is now a `div`. It can safely contain complex children
+        like form inputs without causing HTML nesting errors. The flexbox
+        classes remain the same to preserve the layout.
+      */}
+      <div className="flex flex-col sm:flex-row items-start gap-3 sm:gap-2">
+        {icon && <Info size={18} className="mt-0.5 shrink-0 text-darkLimeGreen" />}
+
+        {/* This content wrapper is also now a `div`. This ensures that
+          whatever you pass as `children` (text, inputs, other components)
+          is placed in a valid container. It also preserves the two-part
+          structure that the flex layout depends on.
+        */}
+        <div>{children}</div>
+      </div>
+    </motion.div>
+  );
+};
+
+export default InfoBox;

--- a/Frontend/src/components/organisms/goals/GoalItem.tsx
+++ b/Frontend/src/components/organisms/goals/GoalItem.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { useFormContext, FieldArrayWithId } from 'react-hook-form';
+import { motion } from 'framer-motion';
+import { Trash2, Info } from 'lucide-react';
+
+import { FormValues } from '@/types/budget/goalTypes';
+import { calcMonthly, calcProgress } from '@/utils/budget/goalCalculations';
+import useAnimatedCounter from '@/hooks/useAnimatedCounter';
+
+import TextInput from '@/components/atoms/InputField/TextInput';
+import FormattedNumberInput from "@components/atoms/InputField/FormattedNumberInput";
+import { idFromPath } from '@/utils/idFromPath';
+import GoalContainer from "@/components/molecules/containers/GoalContainer";
+
+interface GoalItemProps {
+    index: number;
+    item: FieldArrayWithId<FormValues, "goals", "fieldId">;
+    onRemove: (index: number) => void;
+}
+
+const GoalItem: React.FC<GoalItemProps> = ({ index, item, onRemove }) => {
+    const { watch, setValue, formState: { errors } } = useFormContext<FormValues>();
+    const base = `goals.${index}` as const;
+
+    const target = watch(`${base}.targetAmount`);
+    const saved = watch(`${base}.amountSaved`);
+    const date = watch(`${base}.targetDate`);
+
+    const monthly = calcMonthly(target, saved, date);
+    const progress = calcProgress(target, saved);
+    const animatedMonthly = useAnimatedCounter(monthly ?? 0);
+
+    return (
+        <>
+            <div className="grid grid-cols-1 gap-x-6 gap-y-4 md:grid-cols-6">
+                
+                {/* ROW 1: THE NAME. Gets all 6 columns. */}
+                <div className="md:col-span-6">
+                    <label htmlFor={idFromPath(`${base}.name`)} className="block text-xs font-medium text-white/70 mb-1.5">Målets namn</label>
+                    <TextInput
+                        id={idFromPath(`${base}.name`)}
+                        value={watch(`${base}.name`) || ""}
+                        onChange={(e) => setValue(`${base}.name`, e.target.value, { shouldValidate: true, shouldDirty: true })}
+                        placeholder="T.ex. Resa till Sicilien"
+                        error={errors.goals?.[index]?.name?.message}
+                        name={`${base}.name`}
+                    />
+                </div>
+
+                {/* ROW 2: THE MONEY TEAM. They split the 6 columns 3 and 3. */}
+                <div className="md:col-span-3">
+                    <label htmlFor={idFromPath(`${base}.targetAmount`)} className="block text-xs font-medium text-white/70 mb-1.5">Målbelopp (kr)</label>
+                    <FormattedNumberInput
+                        id={idFromPath(`${base}.targetAmount`)}
+                        value={target}
+                        onValueChange={(val) => setValue(`${base}.targetAmount`, val, { shouldValidate: true, shouldDirty: true })}
+                        placeholder="50 000"
+                        error={errors.goals?.[index]?.targetAmount?.message}
+                        name={`${base}.targetAmount`}
+                    />
+                </div>
+                
+                <div className="md:col-span-3">
+                    <label htmlFor={idFromPath(`${base}.amountSaved`)} className="block text-xs font-medium text-white/70 mb-1.5">Redan sparat (kr)</label>
+                    <FormattedNumberInput
+                        id={idFromPath(`${base}.amountSaved`)}
+                        value={saved}
+                        onValueChange={(val) => setValue(`${base}.amountSaved`, val, { shouldValidate: true, shouldDirty: true })}
+                        placeholder="Valfritt"
+                        error={errors.goals?.[index]?.amountSaved?.message}
+                        name={`${base}.amountSaved`}
+                    />
+                </div>
+
+                {/* ROW 3: THE ACTION TEAM. We split this 4 and 2. */}
+                <div className="md:col-span-4">
+                    <label htmlFor={idFromPath(`${base}.targetDate`)} className="block text-xs font-medium text-white/70 mb-1.5">Måldatum</label>
+                    <TextInput
+                        id={idFromPath(`${base}.targetDate`)}
+                        type="date"
+                        value={date || ""}
+                        onChange={(e) => setValue(`${base}.targetDate`, e.target.value, { shouldValidate: true, shouldDirty: true })}
+                        error={errors.goals?.[index]?.targetDate?.message}
+                        name={`${base}.targetDate`}
+                    />
+                </div>
+                
+                <div className="md:col-span-2">
+                    <label className="block text-xs font-medium text-white/70 mb-1.5 opacity-0">Ta bort</label>
+                    <button 
+                        type="button" 
+                        onClick={() => onRemove(index)} 
+                        className="flex h-11 w-full items-center justify-center rounded-lg bg-red-600/80 transition hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-400" 
+                        aria-label="Ta bort mål"
+                    >
+                        <Trash2 size={18} className="text-white" />
+                    </button>
+                </div>
+            </div>
+
+            <div className="mt-6 space-y-2">
+                <div className="h-2 w-full overflow-hidden rounded-full bg-white/20">
+                    <motion.div layout className="h-full rounded-full bg-darkLimeGreen" style={{ width: `${progress}%` }} transition={{ type: "spring", stiffness: 100, damping: 20 }} />
+                </div>
+                <div className="flex items-center justify-between text-sm text-white/80">
+                    <span>Sparat: <span className="font-semibold">{saved?.toLocaleString("sv-SE") ?? 0} kr</span></span>
+                    <span>{progress}% klart</span>
+                </div>
+                {monthly !== null && (
+                    <p className="text-sm text-white/90">Månadssparande: <span className="ml-1.5 font-semibold text-darkLimeGreen">{animatedMonthly.toLocaleString("sv-SE")} kr/mån</span></p>
+                )}
+            </div>
+            <div className="mt-4 border-t border-white/10 pt-3">
+                <div className="flex items-center gap-2 text-xs text-white/60">
+                    <Info size={16} className="text-darkLimeGreen/80" />
+                    <span>Glöm inte, du kan närsomhelst justera ditt mål senare.</span>
+                </div>
+            </div>
+        </>
+    );
+};
+
+export default GoalItem;

--- a/Frontend/src/components/organisms/goals/GoalItem.tsx
+++ b/Frontend/src/components/organisms/goals/GoalItem.tsx
@@ -8,7 +8,7 @@ import { calcMonthly, calcProgress } from '@/utils/budget/goalCalculations';
 import useAnimatedCounter from '@/hooks/useAnimatedCounter';
 
 import TextInput from '@/components/atoms/InputField/TextInput';
-import FormattedNumberInput from "@components/atoms/InputField/FormattedNumberInput";
+import FormattedNumberInput from "@/components/atoms/InputField/FormattedNumberInput";
 import { idFromPath } from '@/utils/idFromPath';
 import GoalContainer from "@/components/molecules/containers/GoalContainer";
 

--- a/Frontend/src/components/organisms/overlays/wizard/SetupWizard.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/SetupWizard.tsx
@@ -1,380 +1,298 @@
-import React, { useState, useEffect, useRef, useCallback, useMemo } from "react";
+import React, { useState, useEffect, useRef, useCallback, useMemo, useLayoutEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import {
-  ChevronLeft,
-  ChevronRight,
-  X,
-  Wallet,
-  User,
-  CheckCircle,
-  CreditCard,
+    ChevronLeft,
+    ChevronRight,
+    X,
+    Wallet,
+    User,
+    CheckCircle,
+    CreditCard,
 } from "lucide-react";
 
-// Container for wizard step content (styling)
+
 import WizardStepContainer from "@components/molecules/containers/WizardStepContainer";
-// Individual step components
 import StepWelcome from "@components/organisms/overlays/wizard/steps/StepWelcome";
-// Importing step components
-// INITIAL STEPS
 import StepBudgetSavings, { StepBudgetSavingsRef } from "@components/organisms/overlays/wizard/steps/StepBudgetSavings3/StepBudgetSavings";
 import StepConfirmation from "@components/organisms/overlays/wizard/steps/StepConfirmation";
-// Step 1: Income 
 import WizardFormWrapperStep1, { WizardFormWrapperStep1Ref } from '@components/organisms/overlays/wizard/steps/StepBudgetIncome1/wrapper/WizardFormWrapperStep1'; 
 import StepBudgetIncome from "@components/organisms/overlays/wizard/steps/StepBudgetIncome1/StepBudgetIncome";
-// Step 2: Expenditure
 import StepExpenditure, { StepBudgetExpenditureRef } from "@components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/StepBudgetExpenditure";
-
-// Toast notification
 import { useToast } from "@context/ToastContext";
-// hooks
 import useSaveWizardStep from "@hooks/wizard/useSaveWizardStep";
 import useWizardInit from "@hooks/wizard/useWizardInit";
 import useMediaQuery from "@hooks/useMediaQuery";
 import useWizardNavigation from "@hooks/wizard/useWizardNavigation";
-// removed per-form hooks; wrappers will handle scrolling to errors
-//local display state
 import useBudgetInfoDisplayFlags from "@hooks/wizard/flagHooks/useBudgetInfoDisplayFlags";
-// Header import
 import WizardHeading from "@components/organisms/overlays/wizard/SharedComponents/Menu/WizardHeading";
 import WizardProgress from "@components/organisms/overlays/wizard/SharedComponents/Menu/WizardProgress";
 import AnimatedContent from "@components/atoms/wrappers/AnimatedContent";
-// Footer import
 import WizardNavPair from "@components/organisms/overlays/wizard/SharedComponents/Buttons/WizardNavPair";
-// Modal import
 import ConfirmModal from "@components/atoms/modals/ConfirmModal";
-// Stores
+import { useWizard, WizardProvider } from '@/context/WizardContext';
+
 
 // ---------------------------- TYPES ----------------------------
 interface SetupWizardProps {
-  onClose: () => void;
+    onClose: () => void;
 }
 
-interface FormValues {
-  showSideIncome: boolean;
-  showHouseholdMembers: boolean;
-}
-
-// ---------------------------- COMPONENT ----------------------------
+// =========================================================================
+// THE MIND OF GANDALF (The Main Component)
+// It holds all state and logic, but renders almost no JSX itself.
+// =========================================================================
 const SetupWizard: React.FC<SetupWizardProps> = ({ onClose }) => {
+    // All of the hooks and state management are safely kept here.
+    const [confirmModalOpen, setConfirmModalOpen] = useState(false);
+    const [showShakeAnimation, setShowShakeAnimation] = useState(false);
+    const { showToast } = useToast();
+    const {
+        loading: initLoading,
+        wizardSessionId,
+        wizardData,
+        setWizardData,
+        failedAttempts,
+        connectionError,
+        initWizard,
+        initialStep,
+        initialSubStep,
+    } = useWizardInit();
+    const { handleSaveStepData } = useSaveWizardStep(wizardSessionId || '');
+    const [transitionLoading, setTransitionLoading] = useState(false);
+    const [currentStepState, setCurrentStepState] = useState<Record<number, any>>({});
+    const [step, setStep] = useState(0);
+    const [isStepValid, setIsStepValid] = useState(true);
+    const isDebugMode = process.env.NODE_ENV === 'development';
+    const step1WrapperRef = useRef<WizardFormWrapperStep1Ref>(null);
+    const StepBudgetExpenditureRef = useRef<StepBudgetExpenditureRef>(null);
+    const step3Ref = useRef<StepBudgetSavingsRef>(null);
+    const stepRefs: { [key: number]: React.RefObject<any> } = { 1: step1WrapperRef, 2: StepBudgetExpenditureRef, 3: step3Ref };
+    const { setShowSideIncome, setShowHouseholdMembers } = useBudgetInfoDisplayFlags();
+    const [subTick, setSubTick] = useState(0);
+    console.log(`%cHAWK TWO: The Wizard's mind awakens. Step: ${step}, SubTick: ${subTick}`, "color: orange;");
 
-  // Handler for clicking an icon to navigate to a step
-  const handleStepClick = (targetStep: number) => {
-    setStep(targetStep);
-  };
+
+    // All the callbacks and effects also remain here, safe and sound.
+    const handleWizardClose = useCallback(() => { setConfirmModalOpen(true); }, []);
+    const handleConfirmCloseWizard = useCallback(() => { setConfirmModalOpen(false); onClose(); }, [onClose]);
+    const handleCancelCloseWizard = useCallback(() => { setConfirmModalOpen(false); }, []);
+    const triggerShakeAnimation = (duration = 1000) => { setShowShakeAnimation(true); setTimeout(() => setShowShakeAnimation(false), duration); };
+    const initialDataForStep = (stepNumber: number) => currentStepState[stepNumber]?.data || wizardData[stepNumber] || {};
+    const initialSubStepForStep = (stepNumber: number) => (currentStepState[stepNumber]?.subStep || initialSubStep) ?? 1;
+    useEffect(() => { if (initialStep > 0) setStep(initialStep); }, [initialStep]);
+    const { nextStep: hookNextStep, prevStep: hookPrevStep } = useWizardNavigation({
+        step, setStep, totalSteps: 4, stepRefs, setTransitionLoading, setCurrentStepState, handleSaveStepData, setWizardData, triggerShakeAnimation, isDebugMode, setShowSideIncome, setShowHouseholdMembers,
+    });
+    useEffect(() => { setIsStepValid(step === 0); }, [step]);
 
 
-  // 1. Wizard closure
-  // State for the confirmation modal
-  const [confirmModalOpen, setConfirmModalOpen] = useState(false);
-  // 1A. Opens the modal for user confirmation
-  const handleWizardClose = useCallback(() => {
-    setConfirmModalOpen(true); // Open the confirmation modal
-  }, [setConfirmModalOpen]);
 
-  //1.1A. Handle closing of the wizard without saving
-  const handleConfirmCloseWizard = useCallback(() => {
-    setConfirmModalOpen(false); // Close the modal
-    onClose(); // Call the parent's onClose callback to close the wizard
-  }, [onClose, setConfirmModalOpen]);
-
-  //1.2B. Handle canceling the closure of the wizard
-  const handleCancelCloseWizard = useCallback(() => {
-    setConfirmModalOpen(false); // Close the modal, wizard stays open
-  }, [setConfirmModalOpen]);
-
-  // 2. Styles and toast
-  const [showShakeAnimation, setShowShakeAnimation] = useState(false);
-  const { showToast } = useToast();
-  // Helper function to trigger shake animation
-  const triggerShakeAnimation = (duration = 1000) => {
-    setShowShakeAnimation(true);
-    setTimeout(() => setShowShakeAnimation(false), duration);
-  };
-  // States:
-  // 3A. State for wizard data, session
-  const {
-    loading: initLoading,
-    wizardSessionId,
-    wizardData,
-    setWizardData,
-    failedAttempts,
-    connectionError,
-    initWizard,
-    initialStep,
-    initialSubStep,
-  } = useWizardInit();
-  // 3B. Handler for saving step data
-  const { handleSaveStepData } = useSaveWizardStep(wizardSessionId || '');
-  // 3C. loading state
-  const [transitionLoading, setTransitionLoading] = useState(false);
-
-  // 3D. State for saving current substep for each step
-  const [currentStepState, setCurrentStepState] = useState<Record<number, any>>({});
-  const initialDataForStep = (stepNumber: number) => {
-    return currentStepState[stepNumber]?.data || wizardData[stepNumber] || {};
-  };
-  // 3E. Initial substep for each step
-  const initialSubStepForStep = (stepNumber: number) => {
-    return (currentStepState[stepNumber]?.subStep || initialSubStep) ?? 1;
-  };
-
-  // 4. Step & validation
-  // Initialize wizard step from server data (if available)
-  const [step, setStep] = useState(0);
-  useEffect(() => {
-    if (initialStep > 0) {
-      setStep(initialStep);
-    }
-  }, [initialStep]);
-  // Total steps and step data
-
-  const totalSteps = 4;
-  const steps = [
-    { icon: Wallet, label: "Inkomster" },
-    { icon: CreditCard, label: "Utgifter" },
-    { icon: User, label: "Sparande" },
-    { icon: CheckCircle, label: "Bekräfta" },
-  ];
-  const [isStepValid, setIsStepValid] = useState(true);
-  const isDebugMode = process.env.NODE_ENV === 'development';
-
-  // 5. Refs to child steps
-  const step1WrapperRef = useRef<WizardFormWrapperStep1Ref>(null);
-  const StepBudgetExpenditureRef = useRef<StepBudgetExpenditureRef>(null);
-  const step3Ref = useRef<StepBudgetSavingsRef>(null);
-
-  // Refs for all steps
-  const stepRefs: { [key: number]: React.RefObject<any> } = {
-    1: step1WrapperRef,
-    2: StepBudgetExpenditureRef,
-    3: step3Ref,
-  };
-
-  // State for local state
-  const { flags, setShowSideIncome, setShowHouseholdMembers } = useBudgetInfoDisplayFlags();
-  const [subTick, setSubTick] = useState(0);
-  const handleSubStepChange = useCallback(() => {
+    const handleSubStepChange = useCallback(() => {
+    // --- The Parent's Ear ---
+    console.log('%cTHE PARENT HEARS: The handleSubStepChange function has been invoked!', 'color: lime; font-weight: bold;');
     setSubTick(t => t + 1);
-  }, []);
+    }, []);
+    const handleStepClick = (targetStep: number) => { setStep(targetStep); };
+    useEffect(() => {
+    // --- The Parent's Heartbeat ---
+    console.log(`%cTHE PARENT'S HEARTBEAT: subTick has settled to ${subTick}. The scroll and nav logic should now update.`, 'color: orange;');
+    }, [subTick]);
 
-  // 6. Handle step navigation
-  // Call the useWizardNavigation hook
-  const { nextStep: hookNextStep, prevStep: hookPrevStep } =
-  useWizardNavigation({
-    step,
-    setStep,
-    totalSteps,
-    stepRefs,
-    setTransitionLoading,
-    setCurrentStepState,
-    handleSaveStepData,
-    setWizardData,
-    triggerShakeAnimation,
-    isDebugMode,
-    setShowSideIncome,
-    setShowHouseholdMembers,
-  });
-
-  //    Otherwise, default to "not valid" until validated
-  useEffect(() => {
-    if (step === 0) {
-      setIsStepValid(true);
-    } else {
-      setIsStepValid(false);
-    }
-  }, [step]);
-
-  // Scroll to top whenever the major or sub step changes
-  const containerRef = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    containerRef.current?.scrollTo({ top: 0, behavior: 'smooth' });
-  }, [step, subTick]);
-
-    /* -----------------------------------------------------------
-    7. Ask the active child step (if any) for its sub-nav API
-    ------------------------------------------------------------*/
-  // State for the active step API
-  const [activeStepAPI, setActiveStepAPI] = useState<any>(null);
-  // 2. Use EFFECT to watch the ref and update the state when the ref is ready.
-  useEffect(() => {
-    // This code runs AFTER every render.
-    const currentRefAPI = stepRefs[step]?.current;
-
-    // If the ref is populated and its value is different from what's in our state...
-    if (currentRefAPI !== activeStepAPI) {
-      // ...update the state! This will trigger a new, corrected render.
-      setActiveStepAPI(currentRefAPI);
-    }
-    
-    // This effect depends on the step and the ref's current value.
-  }, [step, stepRefs[step]?.current, activeStepAPI]);
-  const subNav = useMemo(() => {
-  const api = activeStepAPI; // Read from the reliable state variable.
-
-  // Use the hasSubSteps function for a more explicit check!
-  if (api && typeof api.hasSubSteps === "function" && api.hasSubSteps()) {
-    return {
-      prevSub: api.goPrevSub,
-      nextSub: api.goNextSub,
-      hasPrevSub: typeof api.hasPrevSub === 'function' ? api.hasPrevSub() : false,
-      hasNextSub: typeof api.hasNextSub === 'function' ? api.hasNextSub() : false,
-    };
-  }
-
-  // Default return value
-  return {
-    prevSub: () => {},
-    nextSub: () => {},
-    hasPrevSub: false,
-    hasNextSub: false,
-  };
-}, [activeStepAPI, subTick]); // Now only depends on state.
-
-const isSaving = useMemo(() => {
-    // This logic also reads from the reliable state variable.
-    return activeStepAPI && typeof activeStepAPI.isSaving === 'function'
-      ? activeStepAPI.isSaving()
-      : false;
-}, [activeStepAPI]);
+    const subNav = useMemo(() => {
+        // We look directly at the true source: the ref's current value.
+        const api = stepRefs[step]?.current;
+        if (api && typeof api.hasSubSteps === "function" && api.hasSubSteps()) {
+            return {
+                prevSub: api.goPrevSub,
+                nextSub: api.goNextSub,
+                hasPrevSub: typeof api.hasPrevSub === 'function' ? api.hasPrevSub() : false,
+                hasNextSub: typeof api.hasNextSub === 'function' ? api.hasNextSub() : false,
+            };
+        }
+        // If there's no API, we know the truth: there are no sub-steps.
+        return { prevSub: () => {}, nextSub: () => {}, hasPrevSub: false, hasNextSub: false };
+    }, [step, subTick]); // This now depends on the step and the tick that signals a change.
 
 
-  // media query for small screens
-  const isMobile = useMediaQuery('(max-width: 1367px)');
-  console.log("Current step:", step, "Sub-tick:", subTick, "Is mobile:", isMobile, "Has sub-steps:", subNav.hasNextSub, subNav.hasPrevSub);  
-  // ---------------------------- RENDER ----------------------------
-  return (
-    <div className="fixed inset-0 z-[2000] overflow-y-auto w-full h-full ">
-      <div className="flex items-center justify-center bg-black bg-opacity-50 min-h-screen py-10">
-        <motion.div
-          initial={{ opacity: 0, y: -20 }}
-          animate={{ opacity: 1, y: 0 }}
-          exit={{ opacity: 0, y: 20 }}
-          className="bg-standardMenuColor bg-opacity-40 backdrop-blur-lg p-6 rounded-2xl shadow-xl w-11/12 relative"
-        >
-          {/* Close Button (top-right corner) */}
-          <button
-            type="button"
-            onClick={handleWizardClose}
-            title="Close Wizard"
-            className="absolute top-3 right-3 text-red-600 hover:text-red-800"
-          >
-            <X size={24} />
-          </button>
-          <WizardHeading step={step} type="wizard" />
-          <WizardProgress
-            step={step}
-            totalSteps={totalSteps}
-            steps={steps}
-            onStepClick={handleStepClick}
-          />
-          <AnimatedContent ref={containerRef} animationKey={step} className="mb-6 text-center text-gray-700 h-[60vh] md:h-[70vh] lg:h-auto overflow-y-auto">
-            <WizardStepContainer
-              disableDefaultWidth={step === 2} // disable default for step 2
-              className={
-                step === 2
-                  ? isMobile
-                    ? "max-w-lg"   // normal width on mobile
-                    : "max-w-4xl" // bigger width on larger screens
-                  : ""
-              }
-            >
+    const isSaving = useMemo(() => {
+        // This logic is also purified.
+        const api = stepRefs[step]?.current;
+        return api && typeof api.isSaving === 'function'
+            ? api.isSaving()
+            : false;
+    }, [step, subTick]); // Add subTick here to force a re-check when sub-steps change.
 
-              {step === 0 ? (
-                // Step 0: Welcome
-                <StepWelcome
-                  connectionError={connectionError}
-                  failedAttempts={failedAttempts}
-                  loading={transitionLoading || initLoading}
-                  onRetry={initWizard}
-                />
-              ) : (
-                <>
-                  {step === 1 && (
-                    (wizardSessionId || isDebugMode) ? (
-                      <WizardFormWrapperStep1
-                        ref={step1WrapperRef}
+    const isMobile = useMediaQuery('(max-width: 1367px)');
 
-
-                      >
-                        <StepBudgetIncome
-                          onNext={() => hookNextStep()} // Use the hook's nextStep
-                          onPrev={() => hookPrevStep()} // Use the hook's prevStep 
-                          loading={transitionLoading || initLoading}
-                          stepNumber={1} 
-                        />
-                      </WizardFormWrapperStep1>
-                    ) : (
-                      <p>Tekniskt fel!</p>
-                    )
-                  )}
-                  {step === 2 && <StepExpenditure
-                    ref={StepBudgetExpenditureRef}
-                    setStepValid={setIsStepValid}
-                    wizardSessionId={wizardSessionId || ''}
-                    onSaveStepData={handleSaveStepData}
-                    stepNumber={2}
-                    initialData={initialDataForStep(2)} // Use derived state for initial data
-                    onNext={() => hookNextStep()} // Use the hook's nextStep
-                    onPrev={() => hookPrevStep()} // Use the hook's prevStep
-                    loading={transitionLoading || initLoading}
-                    initialSubStep={initialSubStepForStep(2)} // Use derived state
-                    onSubStepChange={handleSubStepChange}
-                  />}
-                  {step === 3 && (
-                    <StepBudgetSavings
-                        ref={step3Ref}
-                        onNext={() => hookNextStep()}
-                        onPrev={() => hookPrevStep()}
-                        loading={transitionLoading || initLoading}
-                        initialSubStep={initialSubStepForStep(3)}
-                        onSubStepChange={handleSubStepChange}
-                        wizardSessionId={wizardSessionId || ''}
-                        onSaveStepData={handleSaveStepData}
-                        stepNumber={3}
-                        initialData={initialDataForStep(3)}
-                    />
-                  )}
-                  {step === 4 && <StepConfirmation />}
-                </>
-              )}
-
-            </WizardStepContainer>
-
-          </AnimatedContent>
-
-          <div className="w-full max-w-4xl mx-auto">
-            <div className="my-6 w-full flex items-center justify-between">
-              <WizardNavPair
-                step={step}
-                prevStep={subNav.hasPrevSub ? subNav.prevSub : hookPrevStep}
-                nextStep={subNav.hasNextSub ? subNav.nextSub : hookNextStep}
-                hasPrev={subNav.hasPrevSub || step > 0}
-                hasNext={subNav.hasNextSub || step < totalSteps}
-
-                hasPrevSub={subNav.hasPrevSub}
-                hasNextSub={subNav.hasNextSub}
-
-                connectionError={connectionError}
-                initLoading={initLoading}
-                transitionLoading={transitionLoading}
-                isDebugMode={isDebugMode}
+    // Gandalf's only job is to provide the magic and pass his knowledge down to his body.
+    return (
+        <WizardProvider>
+            <WizardContent
+                onClose={onClose}
+                confirmModalOpen={confirmModalOpen}
+                handleWizardClose={handleWizardClose}
+                handleConfirmCloseWizard={handleConfirmCloseWizard}
+                handleCancelCloseWizard={handleCancelCloseWizard}
                 showShakeAnimation={showShakeAnimation}
+                initLoading={initLoading}
+                connectionError={connectionError}
+                failedAttempts={failedAttempts}
+                initWizard={initWizard}
+                transitionLoading={transitionLoading}
+                step={step}
+                totalSteps={4}
+                steps={[
+                    { icon: Wallet, label: "Inkomster" }, { icon: CreditCard, label: "Utgifter" },
+                    { icon: User, label: "Sparande" }, { icon: CheckCircle, label: "Bekräfta" },
+                ]}
+                handleStepClick={handleStepClick}
+
+                isMobile={isMobile}
+                wizardSessionId={wizardSessionId}
+                isDebugMode={isDebugMode}
+                stepRefs={stepRefs}
+                hookNextStep={hookNextStep}
+                hookPrevStep={hookPrevStep}
+                StepBudgetExpenditureRef={StepBudgetExpenditureRef}
+                setIsStepValid={setIsStepValid}
+                handleSaveStepData={handleSaveStepData}
+                initialDataForStep={initialDataForStep}
+                initialSubStepForStep={initialSubStepForStep}
+                handleSubStepChange={handleSubStepChange}
+                step3Ref={step3Ref}
+                subNav={subNav}
                 isSaving={isSaving}
-              />
+            />
+        </WizardProvider>
+    );
+};
+
+// =========================================================================
+// THE BODY OF GANDALF (The Helper Component)
+// It contains all the JSX and lives inside the Provider's magic circle.
+// =========================================================================
+const WizardContent = (props: any) => {
+    // This is where the magic happens, the body of Gandalf.
+    const { isActionBlocked } = useWizard();
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    useLayoutEffect(() => {
+    // We wrap our command in a setTimeout. This tells the browser:
+    // "Finish your current work (painting, layout), and then do this."
+    const timer = setTimeout(() => {
+        containerRef.current?.scrollTo({ top: 0, behavior: 'smooth' });
+    }, 0); // A delay of 0 is all that is needed to wait for the next "tick".
+
+    // A good wizard always cleans up his spells.
+    return () => clearTimeout(timer);
+    }, [props.step, props.subTick]);
+
+    return (
+        <div className="fixed inset-0 z-[2000] overflow-y-auto w-full h-full ">
+            <div className="flex items-center justify-center bg-black bg-opacity-50 min-h-screen py-10">
+                <motion.div
+                    initial={{ opacity: 0, y: -20 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: 20 }}
+                    className="bg-standardMenuColor bg-opacity-40 backdrop-blur-lg p-6 rounded-2xl shadow-xl w-11/12 relative"
+                >
+                    <button type="button" onClick={props.handleWizardClose} title="Close Wizard" className="absolute top-3 right-3 text-red-600 hover:text-red-800">
+                        <X size={24} />
+                    </button>
+                    <WizardHeading step={props.step} type="wizard" />
+                    <WizardProgress step={props.step} totalSteps={props.totalSteps} steps={props.steps} onStepClick={props.handleStepClick} />
+                    <AnimatedContent ref={containerRef} animationKey={`${props.step}-${props.subTick}`} className="mb-6 text-center text-gray-700 h-[60vh] md:h-[70vh] lg:h-auto overflow-y-auto">
+                        <WizardStepContainer disableDefaultWidth={props.step === 2} className={props.step === 2 ? (props.isMobile ? "max-w-lg" : "max-w-4xl") : ""}>
+                            
+                            {/* --- The Heart of the Wizard - Here is your original code, complete and untouched --- */}
+                            {props.step === 0 ? (
+                                <StepWelcome
+                                    connectionError={props.connectionError}
+                                    failedAttempts={props.failedAttempts}
+                                    loading={props.transitionLoading || props.initLoading}
+                                    onRetry={props.initWizard}
+                                />
+                            ) : (
+                                <>
+                                    {props.step === 1 && (
+                                        (props.wizardSessionId || props.isDebugMode) ? (
+                                            <WizardFormWrapperStep1 ref={props.stepRefs[1]}>
+                                                <StepBudgetIncome
+                                                    onNext={props.hookNextStep}
+                                                    onPrev={props.hookPrevStep}
+                                                    loading={props.transitionLoading || props.initLoading}
+                                                    stepNumber={1}
+                                                />
+                                            </WizardFormWrapperStep1>
+                                        ) : (
+                                            <p>Tekniskt fel!</p>
+                                        )
+                                    )}
+                                    {props.step === 2 && <StepExpenditure
+                                        ref={props.stepRefs[2]}
+                                        setStepValid={props.setIsStepValid}
+                                        wizardSessionId={props.wizardSessionId || ''}
+                                        onSaveStepData={props.handleSaveStepData}
+                                        stepNumber={2}
+                                        initialData={props.initialDataForStep(2)}
+                                        onNext={props.hookNextStep}
+                                        onPrev={props.hookPrevStep}
+                                        loading={props.transitionLoading || props.initLoading}
+                                        initialSubStep={props.initialSubStepForStep(2)}
+                                        onSubStepChange={props.handleSubStepChange}
+                                    />}
+                                    {props.step === 3 && (
+                                        <StepBudgetSavings
+                                            ref={props.stepRefs[3]}
+                                            onNext={props.hookNextStep}
+                                            onPrev={props.hookPrevStep}
+                                            loading={props.transitionLoading || props.initLoading}
+                                            initialSubStep={props.initialSubStepForStep(3)}
+                                            onSubStepChange={props.handleSubStepChange}
+                                            wizardSessionId={props.wizardSessionId || ''}
+                                            onSaveStepData={props.handleSaveStepData}
+                                            stepNumber={3}
+                                            initialData={props.initialDataForStep(3)}
+                                        />
+                                    )}
+                                    {props.step === 4 && <StepConfirmation />}
+                                </>
+                            )}
+
+
+                        </WizardStepContainer>
+                    </AnimatedContent>
+                    <div className="w-full max-w-4xl mx-auto">
+                        <div className="my-6 w-full flex items-center justify-between">
+                            <WizardNavPair
+                                step={props.step}
+                                prevStep={props.subNav.hasPrevSub ? props.subNav.prevSub : props.hookPrevStep}
+                                nextStep={props.subNav.hasNextSub ? props.subNav.nextSub : props.hookNextStep}
+                                hasPrev={props.subNav.hasPrevSub || props.step > 0}
+                                hasNext={props.subNav.hasNextSub || props.step < props.totalSteps}
+                                hasPrevSub={props.subNav.hasPrevSub}
+                                hasNextSub={props.subNav.hasNextSub}
+                                connectionError={props.connectionError}
+                                initLoading={props.initLoading}
+                                transitionLoading={props.transitionLoading}
+                                isDebugMode={props.isDebugMode}
+                                showShakeAnimation={props.showShakeAnimation}
+                                isSaving={props.isSaving}
+                                isActionBlocked={isActionBlocked}
+                            />
+                        </div>
+                    </div>
+                </motion.div>
             </div>
-          </div>
-        </motion.div>
-      </div>
-      {/* Confirm Modal */}
-      <ConfirmModal
-        isOpen={confirmModalOpen}
-        title="Är du säker?"
-        description="Om du väljer att avsluta nu så sparas den data du angett i nuvarande form inte"
-        onCancel={handleCancelCloseWizard} // Close modal, wizard stays open
-        onConfirm={handleConfirmCloseWizard} // Close modal, then close wizard via onClose prop
-      />
-    </div>
-  );
+            <ConfirmModal
+                isOpen={props.confirmModalOpen}
+                title="Är du säker?"
+                description="Om du väljer att avsluta nu så sparas den data du angett i nuvarande form inte"
+                onCancel={props.handleCancelCloseWizard}
+                onConfirm={props.handleConfirmCloseWizard}
+            />
+        </div>
+    );
 };
 
 export default SetupWizard;

--- a/Frontend/src/components/organisms/overlays/wizard/SharedComponents/Buttons/WizardNavPair.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/SharedComponents/Buttons/WizardNavPair.tsx
@@ -10,7 +10,6 @@ export interface WizardNavPairProps {
   hasPrev: boolean;
   hasNext: boolean;
   
-  // --- NEW INTEL ---
   // The component now needs to know the sub-step status specifically.
   hasPrevSub: boolean;
   hasNextSub: boolean;
@@ -22,6 +21,7 @@ export interface WizardNavPairProps {
   isDebugMode: boolean;
   showShakeAnimation: boolean;
   isSaving: boolean;
+  isActionBlocked: boolean; 
 }
 
 const WizardNavPair: React.FC<WizardNavPairProps> = ({
@@ -39,6 +39,7 @@ const WizardNavPair: React.FC<WizardNavPairProps> = ({
   isDebugMode,
   showShakeAnimation,
   isSaving,
+  isActionBlocked,
 }) => {
   const isLocked =
     isSaving ||
@@ -48,12 +49,11 @@ const WizardNavPair: React.FC<WizardNavPairProps> = ({
       (connectionError && step === 0)
     ));
 
-  const disablePrev = isLocked || !hasPrev;
-  const disableNext = isLocked || !hasNext;
+    const disablePrev = isLocked || !hasPrev || isActionBlocked;
+    const disableNext = isLocked || !hasNext || isActionBlocked;
 
-  // --- THE REAL FIX: One brain for each button! ---
-  const isPrevMajor = !hasPrevSub; // If there's no sub-step to go back to, it's a major step back.
-  const isNextMajor = !hasNextSub; // If there's no sub-step to go forward to, it's a major step forward.
+  const isPrevMajor = !hasPrevSub; 
+  const isNextMajor = !hasNextSub; 
 
   const IconPrev = isPrevMajor ? Rewind : ChevronLeft;
   const IconNext = isNextMajor ? FastForward : ChevronRight;

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/2_SubStepRent/components/HomeTypeOption.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/2_SubStepRent/components/HomeTypeOption.tsx
@@ -85,7 +85,7 @@ const HomeTypeOption: React.FC = () => {
 
   if (effectiveHomeType === "rent") {
     renderedHomeTypeSection = (
-      <OptionContainer>
+      <OptionContainer className="p-4"> 
 
         <p className="text-center text-customBlue1 text-lg mb-4">
           Enkelt och smidigt! Fyll i din månadshyra. Under övrigt så anger du fasta utgifter, såsom el, vatten och annat kopplat till boendekostnader per månad.
@@ -142,7 +142,7 @@ const HomeTypeOption: React.FC = () => {
     );
   } else if (effectiveHomeType === "brf") {
     renderedHomeTypeSection = (
-      <OptionContainer>
+      <OptionContainer className="p-4">
         <p className="text-center text-customBlue1 text-lg">
           Härligt med något eget! Här anger du din månadsavgift till föreningen. Under övrigt så anger du fasta utgifter, såsom el, vatten och annat kopplat till boendekostnader per månad.
         </p>
@@ -193,7 +193,7 @@ const HomeTypeOption: React.FC = () => {
     );
   } else if (effectiveHomeType === "house") {
     renderedHomeTypeSection = (
-      <OptionContainer>
+      <OptionContainer className="p-4">
         <p className="text-center text-customBlue1 text-lg">
           Frihet och ansvar! Här anger du din bolånebetalning. Under övrigt så anger du fasta utgifter, såsom el, vatten och annat kopplat till boendekostnader per månad.
         </p>
@@ -245,7 +245,7 @@ const HomeTypeOption: React.FC = () => {
     );
   } else if (effectiveHomeType === "free") {
     renderedHomeTypeSection = (
-      <OptionContainer>
+      <OptionContainer className="p-4">
         <p className="text-center text-customBlue1 text-lg">
           Om du ändå har några kostnader kopplade till boendet (t.ex. el, vatten), fyll gärna i dem här.
         </p>

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/3_SubStepFood/SubStepFood.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/3_SubStepFood/SubStepFood.tsx
@@ -121,7 +121,7 @@ const calculatedTotalValue = (foodStoreExpenses ?? 0) + (takeoutExpenses ?? 0);
 const formattedTotalValue = calculatedTotalValue.toLocaleString("sv-SE");
 
   return (
-    <OptionContainer>
+    <OptionContainer className="p-4">
       <div className="flex justify-center md:mt-4">
         <div className="">
           <GlossyFlipCard

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/4_SubStepFixedExpenses/SubStepFixedExpenses.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/4_SubStepFixedExpenses/SubStepFixedExpenses.tsx
@@ -112,7 +112,7 @@ const SubStepFixedExpenses: React.FC = () => {
 
 
   return (
-    <OptionContainer>
+    <OptionContainer className="p-4">
       <section className="w-auto mx-auto sm:px-6 lg:px-12 py-8 pb-safe">
         <div className="flex justify-center md:mt-4">
           <GlossyFlipCard

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/5_SubStepTransport/SubStepTransport.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/5_SubStepTransport/SubStepTransport.tsx
@@ -20,7 +20,7 @@ const SubStepTransport: React.FC = () => {
   const { formState: { errors } } = useFormContext<TransportForm>();
 
   return (
-    <OptionContainer>
+    <OptionContainer className="p-4">
       <section className="w-auto mx-auto sm:px-6 lg:px-12 py-8 pb-safe">
         <div className="flex justify-center md:mt-4 mb-10">
           <GlossyFlipCard

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/6_SubStepClothing/SubStepClothing.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/6_SubStepClothing/SubStepClothing.tsx
@@ -33,7 +33,7 @@ const SubStepClothing: React.FC = () => {
   const reg = register(fieldPath);
 
   return (
-    <OptionContainer>
+    <OptionContainer className="p-4">
       <motion.section
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/7_SubStepSubscriptions/SubStepSubscriptions.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/7_SubStepSubscriptions/SubStepSubscriptions.tsx
@@ -91,7 +91,7 @@ const SubStepSubscriptions: React.FC = () => {
   };
 
   return (
-    <OptionContainer>
+    <OptionContainer className="p-4">
       <section className="w-auto mx-auto sm:px-6 lg:px-12 py-8 pb-safe">
         <div className="flex justify-center md:mt-4">
           <GlossyFlipCard

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/8_SubStepConfirm/SubStepConfirm.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/Components/Pages/SubSteps/8_SubStepConfirm/SubStepConfirm.tsx
@@ -186,7 +186,7 @@ const SubStepConfirm: React.FC = () => {
   const doughnutSlices = allCategories.map(({ name, value }) => ({ name, value }));
 
   return (
-    <OptionContainer>
+    <OptionContainer className="p-4">
       {/* 1. Header & Welcome */}
       <section className="space-y-6 text-white">
         <motion.h3

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetIncome1/StepBudgetIncome.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetIncome1/StepBudgetIncome.tsx
@@ -240,7 +240,7 @@ const {
         <Lottie animationData={coinsAnimation} className="w-24 h-24" loop />
       </div>
 
-      <OptionContainer>
+      <OptionContainer className="p-4">
         <SalaryField
           netSalaryFieldName="netSalary"
           salaryFrequencyFieldName="salaryFrequency"
@@ -259,7 +259,7 @@ const {
       </OptionContainer>
 
       {/* Optional Household Members Section */}
-      <OptionContainer>
+      <OptionContainer className="p-4">
         <div className="flex items-center justify-center mt-4 gap-x-2 mb-3">
           <h4 className="text-lg font-semibold">Hushålls&shy;medlemmar&nbsp;(valfritt)</h4>
           <HelpSectionDark
@@ -349,7 +349,7 @@ const {
       </OptionContainer>
 
       {/* Side Hustle Section */}
-      <OptionContainer>
+      <OptionContainer className="p-4">
         <div className="flex items-center justify-center mt-4 gap-x-2 mb-3"> {/* Changed gap-2 to gap-x-2 */}
           <h4 className="text-lg font-semibold">Övriga inkomster (valfritt)</h4>
           <HelpSectionDark

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetSavings3/Components/Pages/SubSteps/1_SubStepIntro/SubStepIntro.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetSavings3/Components/Pages/SubSteps/1_SubStepIntro/SubStepIntro.tsx
@@ -4,7 +4,7 @@ import { motion } from 'framer-motion';
 import OptionContainer from '@components/molecules/containers/OptionContainer';
 import { Step3FormValues } from '@/schemas/wizard/StepSavings/step3Schema';
 import BirdIllustration from '@assets/Images/bird_freedom.png';
-
+import InfoBox from "@/components/molecules/messaging/InfoBox";
 /**
  * SubStepIntro – Savings introduction step
  * Adds a floating bird illustration in the top‑right corner to create a sense of
@@ -15,7 +15,7 @@ const SubStepIntro: React.FC = () => {
   const selected = watch('savingHabit');
 
   return (
-    <OptionContainer>
+    <OptionContainer className="p-4">
       {/* Relative wrapper allows absolute positioning of the bird */}
       <section className="relative max-w-xl mx-auto sm:px-6 lg:px-12 py-8 pb-safe space-y-8">
         {/* Floating bird – sits in the corner, gently bobbing */}
@@ -33,10 +33,10 @@ const SubStepIntro: React.FC = () => {
           <h3 className="text-2xl font-bold text-darkLimeGreen">
             Din resa mot ekonomisk frihet börjar här
           </h3>
-          <p className="text-white">
+          <InfoBox>
             Att spara pengar är ett kraftfullt steg mot nya möjligheter. Hur ser dina
             sparvanor ut idag?
-          </p>
+          </InfoBox>
         </header>
 
         {/* Radio Group */}

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetSavings3/Components/Pages/SubSteps/2_SubStepHabits/SubStepHabits.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetSavings3/Components/Pages/SubSteps/2_SubStepHabits/SubStepHabits.tsx
@@ -1,30 +1,16 @@
-import React, { useState, useRef } from "react";
+import React from "react";
 import { useFormContext } from "react-hook-form";
-import { motion, AnimatePresence } from "framer-motion";
-import { Pencil } from "lucide-react";
-import OptionContainer from "@components/molecules/containers/OptionContainer";
-import RangeSlider from "@components/atoms/InputField/RangeSlider";
-import HelpSection from "@components/molecules/helptexts/HelpSection";
+
+// --- Component Imports (Paths to be adjusted) ---
+import OptionContainer from "@/components/molecules/containers/OptionContainer";
+import HelpSection from "@/components/molecules/helptexts/HelpSection";
+import CheckboxOption from "@/components/atoms/InputField/CheckboxOption";
+import EditableSavingsInput from "@/components/molecules/InputField/EditableSavingsInput"; 
+import InfoBox from "@/components/molecules/messaging/InfoBox";
+// --- Store, Schema, and Utility Imports ---
 import { useWizardDataStore } from "@/stores/Wizard/wizardDataStore";
 import { Step3FormValues } from "@/schemas/wizard/StepSavings/step3Schema";
 import { calcMonthlyIncome } from "@/utils/wizard/wizardHelpers";
-
-interface CheckboxOptionProps extends React.InputHTMLAttributes<HTMLInputElement> {
-  id: string;
-  label: string;
-}
-
-const CheckboxOption: React.FC<CheckboxOptionProps> = ({ id, label, ...props }) => (
-  <label htmlFor={id} className="flex items-center space-x-3 p-3 bg-white/5 hover:bg-white/10 rounded-lg cursor-pointer transition-colors">
-    <input
-      id={id}
-      type="checkbox"
-      className="h-5 w-5 rounded border-gray-300 text-lime-500 focus:ring-lime-400 bg-transparent"
-      {...props}
-    />
-    <span className="text-white font-medium">{label}</span>
-  </label>
-);
 
 const SubStepHabits: React.FC = () => {
   const { watch, setValue, formState: { errors } } = useFormContext<Step3FormValues>();
@@ -33,22 +19,7 @@ const SubStepHabits: React.FC = () => {
   const maxIncome = calcMonthlyIncome(income);
 
   const monthlySavings = watch("monthlySavings");
-  const savingMethods = watch("savingMethods"); // Watch the value directly
-
-  const [editing, setEditing] = useState(false);
-  const [showHint, setShowHint] = useState(true);
-  const inputRef = useRef<HTMLInputElement | null>(null);
-
-  const commit = () => {
-    const raw = Number(inputRef.current?.value ?? monthlySavings ?? 0);
-    const clamped = Math.min(Math.max(raw, 0), maxIncome);
-    setValue("monthlySavings", clamped, { shouldValidate: true, shouldDirty: true });
-    setEditing(false);
-  };
-  
-  const cancel = () => {
-    setEditing(false);
-  };
+  const savingMethods = watch("savingMethods");
 
   const options = [
     { value: "auto", label: "Automatiska överföringar" },
@@ -58,7 +29,6 @@ const SubStepHabits: React.FC = () => {
   ];
 
   const handleCheckboxChange = (value: string) => {
-
     const currentValues = Array.isArray(savingMethods) ? [...savingMethods] : [];
 
     if (value === 'prefer_not') {
@@ -82,123 +52,63 @@ const SubStepHabits: React.FC = () => {
   const checkedMethods = Array.isArray(savingMethods) ? savingMethods : [];
 
   return (
-    <OptionContainer>
+    <OptionContainer className="p-4">
       <section className="max-w-xl mx-auto sm:px-6 lg:px-12 py-8 pb-safe space-y-10">
         <header className="space-y-4 text-center">
+          {/* Header content */}
           <h3 className="text-3xl font-bold text-darkLimeGreen flex justify-center items-center gap-2">
             Perfekt! Låt oss kolla på dina sparvanor
           </h3>
-          <p className="text-white opacity-90 text-sm">
+          <InfoBox>
             Med denna informationen kan vi sätta upp långsiktiga mål och hjälpa dig att spara smartare.
-          </p>
+          </InfoBox>
         </header>
+        <InfoBox icon={false}>
+          <div>
+            <label
+              id="monthlySavingsLabel"
+              className="block text-sm font-medium text-standardMenuColor/90 dark:text-standardMenuColor mb-4"
+            >
+              Ungefär hur mycket sparar du varje månad?
+            </label>
+            <EditableSavingsInput
+              value={sliderValue}
+              max={maxIncome}
+              onChange={(newValue) => setValue("monthlySavings", newValue, { shouldValidate: true, shouldDirty: true })}
+              aria-labelledby="monthlySavingsLabel"
+            />
+          </div>
 
-        <div className="space-y-4">
-          <label
-            htmlFor="monthlySavingsInput"
-            id="monthlySavingsLabel"
-            className="block text-sm font-medium text-standardMenuColor/90 dark:text-standardMenuColor"
-          >
-            Ungefär hur mycket sparar du varje månad?
-          </label>
-          <RangeSlider
-            min={0}
-            max={maxIncome}
-            value={sliderValue}
-            onChange={(val) => setValue("monthlySavings", val, { shouldValidate: true, shouldDirty: true })}
-            aria-labelledby="monthlySavingsLabel"
-          />
-          <div className="flex flex-col items-center">
-            <AnimatePresence mode="wait" initial={false}>
-              {editing ? (
-                <motion.input
-                  key="input"
-                  ref={inputRef}
-                  id="monthlySavingsInput"
-                  aria-label="Redigera månatligt sparbelopp, kronor"
-                  title="Månatligt sparbelopp"
-                  placeholder="0"
-                  type="number"
-                  min={0}
-                  max={maxIncome}
-                  step={100}
-                  defaultValue={sliderValue} 
-                  onBlur={commit}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") commit();
-                    if (e.key === "Escape") cancel();
-                  }}
-                  className="w-40 text-3xl leading-none bg-transparent text-center font-bold text-white outline-none border-b-2 border-limeGreen focus:border-darkLimeGreen tabular-nums"
-                  initial={{ scale: 0.9, opacity: 0 }}
-                  animate={{ scale: 1, opacity: 1 }}
-                  exit={{ scale: 0.9, opacity: 0 }}
-                  autoFocus
+          <div className="space-y-2">
+            
+            <label className="text-sm font-medium text-standardMenuColor/90 dark:text-standardMenuColor" id="saving-methods-label">
+              Hur brukar du spara? (Välj alla som passar)
+            </label>
+            <div className="space-y-3" role="group" aria-labelledby="saving-methods-label">
+              {options.map((option) => (
+                <CheckboxOption
+                  key={option.value}
+                  id={`saving-method-${option.value}`}
+                  label={option.label}
+                  value={option.value}
+                  checked={checkedMethods.includes(option.value)}
+                  onChange={() => handleCheckboxChange(option.value)}
                 />
-              ) : (
-                <motion.button
-                  key="label"
-                  type="button"
-                  onClick={() => {
-                    setEditing(true);
-                    setShowHint(false);
-                  }}
-                  className="group flex items-center text-white/90 hover:text-limeGreen/95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-limeGreen rounded-md cursor-pointer"
-                  initial={{ scale: 0.9, opacity: 0 }}
-                  animate={{ scale: 1, opacity: 1 }}
-                  exit={{ scale: 0.9, opacity: 0 }}
-                >
-                  <span className="text-3xl leading-none font-bold tabular-nums">
-                    {sliderValue.toLocaleString("sv-SE")}
-                  </span>
-                  <span className="ml-1 text-lg leading-none font-semibold">kr</span>
-                  <Pencil className="ml-2 w-6 h-6 opacity-60 group-hover:opacity-100 transition-opacity" />
-                </motion.button>
-              )}
-            </AnimatePresence>
-            {showHint && !editing && (
-              <motion.p
-                key="hint"
-                className="mt-1 text-xs text-gray-300/80"
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                transition={{ delay: 0.4 }}
-              >
-                Klicka för att redigera eller ange ett exakt belopp
-              </motion.p>
+              ))}
+            </div>
+            {errors.savingMethods && (
+              <p className="text-sm text-red-500 mt-2" role="alert">
+                {errors.savingMethods.message}
+              </p>
             )}
+            <div id="savingMethods" style={{ height: 0 }} />
+            <HelpSection
+              label="Varför frågar vi detta?"
+              className="mt-2 text-xs text-standardMenuColor/80"
+              helpText="Vi undrar hur du vanligtvis sätter undan pengar eftersom det påverkar hur stabilt sparandet blir. Om du sparar manuellt kan vi senare tipsa om automatiska överföringar om dina mål inte nås. Vill du inte svara är det helt okej – välj bara 'Vill inte ange'."
+            />
           </div>
-        </div>
-
-        <div className="space-y-2">
-          <label className="text-sm font-medium text-standardMenuColor/90 dark:text-standardMenuColor" id="saving-methods-label">
-            Hur brukar du spara? (Välj alla som passar)
-          </label>
-          
-          <div className="space-y-3" role="group" aria-labelledby="saving-methods-label">
-            {options.map((option) => (
-              <CheckboxOption
-                key={option.value}
-                id={`saving-method-${option.value}`}
-                label={option.label}
-                value={option.value}
-                checked={checkedMethods.includes(option.value)} // Use the safe array value
-                onChange={() => handleCheckboxChange(option.value)}
-              />
-            ))}
-          </div>
-
-          {errors.savingMethods && (
-            <p className="text-sm text-red-500 mt-2" role="alert">
-              {errors.savingMethods.message}
-            </p>
-          )}
-          <div id="savingMethods" style={{ height: 0 }} />
-          <HelpSection
-            label="Varför frågar vi detta?"
-            className="mt-2 text-xs text-standardMenuColor/80"
-            helpText="Vi undrar hur du vanligtvis sätter undan pengar eftersom det påverkar hur stabilt sparandet blir. Om du sparar manuellt kan vi senare tipsa om automatiska överföringar om dina mål inte nås. Vill du inte svara är det helt okej – välj bara 'Vill inte ange'."
-          />
-        </div>
+        </InfoBox>
       </section>
     </OptionContainer>
   );

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetSavings3/Components/Pages/SubSteps/3_SubStepGoals/SubStepGoals.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetSavings3/Components/Pages/SubSteps/3_SubStepGoals/SubStepGoals.tsx
@@ -1,10 +1,128 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useFormContext, useFieldArray } from 'react-hook-form';
+import { motion } from 'framer-motion';
+import { PlusCircle, Trash2 } from 'lucide-react';
 
-const SubStepGoals: React.FC = () => (
-  <div className="p-4 text-white">
-    <h3 className="text-2xl font-bold text-darkLimeGreen mb-4 text-center">Lägg till sparmål</h3>
-    <p className="text-center">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros elementum.</p>
-  </div>
-);
+import OptionContainer from '@components/molecules/containers/OptionContainer';
+import TextInput from '@components/atoms/InputField/TextInput';
+import FormattedNumberInput from '@components/atoms/InputField/FormattedNumberInput';
+import { idFromPath } from '@/utils/idFromPath';
+import { Step3FormValues } from '@/schemas/wizard/StepSavings/step3Schema';
+
+const calcMonthly = (target: number | null, saved: number | null, date: string): number | null => {
+  if (!target || !date) return null;
+  const remaining = target - (saved ?? 0);
+  if (remaining <= 0) return 0;
+  const now = new Date();
+  const end = new Date(date);
+  const months = (end.getFullYear() - now.getFullYear()) * 12 + (end.getMonth() - now.getMonth()) + 1;
+  if (months <= 0) return null;
+  return Math.ceil(remaining / months);
+};
+
+const SubStepGoals: React.FC = () => {
+  const { control, watch, setValue, formState: { errors } } = useFormContext<Step3FormValues>();
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: 'goals',
+    keyName: 'fieldId',
+    shouldUnregister: true,
+  });
+
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const handleAdd = () => {
+    append({ id: crypto.randomUUID(), name: '', targetAmount: null, targetDate: '', amountSaved: null });
+  };
+
+  return (
+    <OptionContainer>
+      <section className="w-auto mx-auto sm:px-6 lg:px-12 py-8 pb-safe space-y-6">
+        <div className="flex justify-between items-center">
+          <h3 className="text-xl font-bold text-darkLimeGreen">Sparmål</h3>
+          <button
+            type="button"
+            onClick={handleAdd}
+            className="flex items-center gap-2 px-3 py-1 bg-limeGreen text-black rounded-md"
+          >
+            <PlusCircle size={18} /> Lägg till mål
+          </button>
+        </div>
+
+        <div className="space-y-4">
+          {fields.map((item, index) => {
+            const base = `goals.${index}`;
+            const target = watch(`${base}.targetAmount` as const);
+            const saved = watch(`${base}.amountSaved` as const);
+            const date = watch(`${base}.targetDate` as const);
+            const monthly = calcMonthly(target, saved, date);
+
+            return (
+              <motion.div
+                key={item.fieldId}
+                layout
+                initial={{ opacity: 0, scale: 0.8, y: 20 }}
+                animate={deletingId === item.fieldId ? 'exit' : 'animate'}
+                variants={{ animate: { opacity: 1, scale: 1, y: 0 }, exit: { opacity: 0, scale: 0.8, x: -300 } }}
+                onAnimationComplete={() => { if (deletingId === item.fieldId) remove(index); }}
+                className="bg-white/10 rounded-xl p-4 space-y-3"
+              >
+                <div className="grid md:grid-cols-5 gap-3">
+                  <TextInput
+                    id={idFromPath(`${base}.name`)}
+                    value={watch(`${base}.name`) || ''}
+                    onChange={(e) => setValue(`${base}.name`, e.target.value, { shouldValidate: true, shouldDirty: true })}
+                    placeholder="Namn på mål"
+                    error={(errors.goals as any)?.[index]?.name?.message}
+                    name={`${base}.name`}
+                    className="md:col-span-2"
+                  />
+                  <FormattedNumberInput
+                    id={idFromPath(`${base}.targetAmount`)}
+                    value={target ?? null}
+                    onValueChange={(val) => setValue(`${base}.targetAmount`, val ?? null, { shouldValidate: true, shouldDirty: true })}
+                    placeholder="Belopp"
+                    error={(errors.goals as any)?.[index]?.targetAmount?.message}
+                    name={`${base}.targetAmount`}
+                  />
+                  <TextInput
+                    id={idFromPath(`${base}.targetDate`)}
+                    type="date"
+                    value={date || ''}
+                    onChange={(e) => setValue(`${base}.targetDate`, e.target.value, { shouldValidate: true, shouldDirty: true })}
+                    placeholder="Datum"
+                    error={(errors.goals as any)?.[index]?.targetDate?.message}
+                    name={`${base}.targetDate`}
+                  />
+                  <FormattedNumberInput
+                    id={idFromPath(`${base}.amountSaved`)}
+                    value={saved ?? null}
+                    onValueChange={(val) => setValue(`${base}.amountSaved`, val ?? null, { shouldValidate: true, shouldDirty: true })}
+                    placeholder="Sparat (valfritt)"
+                    error={(errors.goals as any)?.[index]?.amountSaved?.message}
+                    name={`${base}.amountSaved`}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setDeletingId(item.fieldId)}
+                    className="p-2 bg-red-600 hover:bg-red-700 text-white rounded self-center"
+                    aria-label="Ta bort mål"
+                  >
+                    <Trash2 size={18} />
+                  </button>
+                </div>
+                {monthly !== null && (
+                  <p className="text-sm text-white/80">
+                    Månadssparande för att nå målet: <span className="font-semibold">{monthly.toLocaleString('sv-SE')} kr/mån</span>
+                  </p>
+                )}
+              </motion.div>
+            );
+          })}
+        </div>
+      </section>
+    </OptionContainer>
+  );
+};
 
 export default SubStepGoals;

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetSavings3/Components/StepBudgetSavingsContainer.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetSavings3/Components/StepBudgetSavingsContainer.tsx
@@ -194,9 +194,16 @@ const StepBudgetSavingsContainer = forwardRef<
   const clickProgress = (d: number) => goToSub(d);
 
   /* 6 ─── notify parent of sub-step -------------------------------- */
-  useEffect(() => {
-    onSubStepChange?.(currentSub);
-  }, [currentSub, onSubStepChange]);
+useEffect(() => {
+  // --- The Child's Proclamation ---
+  console.log(
+    `%cTHE CHILD PROCLAIMS: Sub-step is now ${currentSub}. Notifying parent...`,
+    'color: cyan;',
+    `(Is onSubStepChange a function? ${typeof onSubStepChange === 'function'})`
+  );
+
+  onSubStepChange?.(currentSub);
+}, [currentSub, onSubStepChange]);
 
   /* 7 ─── imperative API ------------------------------------------- */
   useImperativeHandle(ref, () => ({

--- a/Frontend/src/context/WizardContext.tsx
+++ b/Frontend/src/context/WizardContext.tsx
@@ -1,0 +1,26 @@
+import React, { createContext, useState, useContext, ReactNode } from 'react';
+
+interface IWizardContext {
+  isActionBlocked: boolean;
+  setIsActionBlocked: (isBlocked: boolean) => void;
+}
+
+const WizardContext = createContext<IWizardContext | undefined>(undefined);
+
+export const WizardProvider = ({ children }: { children: ReactNode }) => {
+  const [isActionBlocked, setIsActionBlocked] = useState(false);
+
+  return (
+    <WizardContext.Provider value={{ isActionBlocked, setIsActionBlocked }}>
+      {children}
+    </WizardContext.Provider>
+  );
+};
+
+export const useWizard = () => {
+  const context = useContext(WizardContext);
+  if (context === undefined) {
+    throw new Error('useWizard must be used within a WizardProvider');
+  }
+  return context;
+};

--- a/Frontend/src/hooks/useAnimatedCounter.ts
+++ b/Frontend/src/hooks/useAnimatedCounter.ts
@@ -1,0 +1,53 @@
+import { useState, useEffect, useRef } from "react";
+
+/**
+ * A custom hook that animates a number from its previous value to a new end value.
+ * It uses requestAnimationFrame for smooth, performant animations.
+ * @param endValue The target number to animate to.
+ * @param duration The duration of the animation in milliseconds.
+ * @returns The current value of the animated number.
+ */
+const useAnimatedCounter = (endValue: number, duration = 500): number => {
+  const [count, setCount] = useState(0);
+  const animationFrameRef = useRef<number>();
+  const previousValueRef = useRef(0);
+
+  useEffect(() => {
+    const startValue = previousValueRef.current;
+    const targetValue = endValue ?? 0; // Gracefully handle null/undefined
+    let startTime: number | null = null;
+
+    const animate = (timestamp: number) => {
+      if (!startTime) startTime = timestamp;
+      const elapsedTime = timestamp - startTime;
+      const progress = Math.min(elapsedTime / duration, 1);
+      
+      const currentValue = startValue + (targetValue - startValue) * progress;
+      setCount(currentValue);
+
+      if (progress < 1) {
+        animationFrameRef.current = requestAnimationFrame(animate);
+      } else {
+        // Ensure it ends precisely on the target value
+        setCount(targetValue);
+        previousValueRef.current = targetValue;
+      }
+    };
+
+    animationFrameRef.current = requestAnimationFrame(animate);
+
+    // Cleanup function
+    return () => {
+      if (animationFrameRef.current) {
+        cancelAnimationFrame(animationFrameRef.current);
+      }
+      // Set the "previous" value to the latest state value on cleanup
+      // This ensures the next animation starts from the right place
+      previousValueRef.current = targetValue; 
+    };
+  }, [endValue, duration]);
+
+  return Math.ceil(count);
+};
+
+export default useAnimatedCounter;

--- a/Frontend/src/hooks/wizard/useWizardNavigation.ts
+++ b/Frontend/src/hooks/wizard/useWizardNavigation.ts
@@ -47,6 +47,10 @@ const useWizardNavigation = ({
 
   const navigateStep = useCallback(
     async (direction: 'next' | 'prev') => {
+      console.log(
+        `%cTHE GREAT ROAD: A request to navigate '${direction}' from step ${step} has begun.`,
+        'color: #FFD700; background: #333; font-weight: bold; padding: 2px 5px; border-radius: 3px;'
+      );
       setTransitionLoading(true);
 
       const ref = stepRefs[step];

--- a/Frontend/src/schemas/wizard/StepSavings/SubSchemas/goalsSchema.ts
+++ b/Frontend/src/schemas/wizard/StepSavings/SubSchemas/goalsSchema.ts
@@ -1,5 +1,13 @@
 import * as yup from 'yup';
 
+
+const today = new Date();
+today.setHours(0, 0, 0, 0);
+
+const maxYearsInFuture = 40; 
+const maxDate = new Date();
+maxDate.setFullYear(maxDate.getFullYear() + maxYearsInFuture);
+
 export const goalItemSchema = yup.object({
   id: yup.string().optional(),
   name: yup.string().trim().required('Ange ett namn på målet.'),
@@ -9,15 +17,26 @@ export const goalItemSchema = yup.object({
     .nullable()
     .required('Ange målbelopp.')
     .min(1, 'Beloppet måste vara > 0 kr.'),
+  
   targetDate: yup
-    .string()
-    .required('Ange ett måldatum.'),
+    .date() 
+    .transform((value, originalValue) => {
+       
+        return originalValue === "" ? null : value;
+    })
+    .typeError('Välj ett giltigt datum.') 
+    .required('Ange ett måldatum.')
+    .min(today, 'Måldatumet kan inte vara i dåtiden.')
+    .max(maxDate, `Målet kan inte vara mer än ${maxYearsInFuture} år framåt i tiden.`),
+    
+
   amountSaved: yup
     .number()
     .typeError('Ange ett giltigt belopp.')
     .nullable()
     .min(0, 'Beloppet måste vara >= 0 kr.'),
 });
+
 
 export const goalsSchema = yup.array(goalItemSchema).nullable();
 export type GoalItem = yup.InferType<typeof goalItemSchema>;

--- a/Frontend/src/schemas/wizard/StepSavings/SubSchemas/goalsSchema.ts
+++ b/Frontend/src/schemas/wizard/StepSavings/SubSchemas/goalsSchema.ts
@@ -1,0 +1,23 @@
+import * as yup from 'yup';
+
+export const goalItemSchema = yup.object({
+  id: yup.string().optional(),
+  name: yup.string().trim().required('Ange ett namn på målet.'),
+  targetAmount: yup
+    .number()
+    .typeError('Ange ett giltigt belopp.')
+    .nullable()
+    .required('Ange målbelopp.')
+    .min(1, 'Beloppet måste vara > 0 kr.'),
+  targetDate: yup
+    .string()
+    .required('Ange ett måldatum.'),
+  amountSaved: yup
+    .number()
+    .typeError('Ange ett giltigt belopp.')
+    .nullable()
+    .min(0, 'Beloppet måste vara >= 0 kr.'),
+});
+
+export const goalsSchema = yup.array(goalItemSchema).nullable();
+export type GoalItem = yup.InferType<typeof goalItemSchema>;

--- a/Frontend/src/schemas/wizard/StepSavings/step3Schema.ts
+++ b/Frontend/src/schemas/wizard/StepSavings/step3Schema.ts
@@ -1,5 +1,6 @@
 import * as yup from 'yup';
 import { savingHabitsSchema } from './SubSchemas/savingHabitsSchema';
+import { goalsSchema } from './SubSchemas/goalsSchema';
 
 export const step3Schema = yup.object({
   // Field from the Intro sub-step
@@ -11,13 +12,7 @@ export const step3Schema = yup.object({
   ...savingHabitsSchema.fields,
 
   // Fields from the Goals sub-step
-  goals: yup.array(
-    yup.object({
-      id: yup.string().optional(),
-      name: yup.string().required(),
-      amount: yup.number().nullable(),
-    })
-  ).nullable(),
+  goals: goalsSchema,
 });
 
 export type Step3FormValues = yup.InferType<typeof step3Schema>;

--- a/Frontend/src/stores/Wizard/wizardDataStore.ts
+++ b/Frontend/src/stores/Wizard/wizardDataStore.ts
@@ -68,7 +68,7 @@ const initialWizardDataState: WizardData = {
   savings: {
     savingHabit: '',
     monthlySavings: null,
-    savingMethods: [], 
+    savingMethods: [],
     goals: [],
   },
 };

--- a/Frontend/src/types/budget/goalTypes.tsx
+++ b/Frontend/src/types/budget/goalTypes.tsx
@@ -1,0 +1,13 @@
+// Type for a single savings goal
+export type Goal = {
+  id: string; // The backend ID, not the field array ID
+  name: string;
+  targetAmount: number | null;
+  targetDate: string;
+  amountSaved: number | null;
+};
+
+// Type for the entire form's values, used in react-hook-form
+export type FormValues = {
+  goals: Goal[];
+};

--- a/Frontend/src/utils/budget/goalCalculations.tsx
+++ b/Frontend/src/utils/budget/goalCalculations.tsx
@@ -1,0 +1,27 @@
+export const calcMonthly = (
+  target: number | null | undefined,
+  saved: number | null | undefined,
+  date: string | null | undefined
+): number | null => {
+  if (!target || !date) return null;
+  const remaining = target - (saved ?? 0);
+  if (remaining <= 0) return 0;
+
+  const now = new Date();
+  now.setHours(0, 0, 0, 0);
+  const end = new Date(date);
+  if (end <= now) return remaining;
+
+  const months = (end.getFullYear() - now.getFullYear()) * 12 + (end.getMonth() - now.getMonth()) + 1;
+  if (months <= 0) return remaining;
+
+  return Math.ceil(remaining / months);
+};
+
+export const calcProgress = (
+  target: number | null | undefined,
+  saved: number | null | undefined
+): number => {
+  if (!target || target === 0) return 0;
+  return Math.min(100, Math.round(((saved ?? 0) / target) * 100));
+};

--- a/Frontend/src/utils/wizard/ensureStep3Defaults.tsx
+++ b/Frontend/src/utils/wizard/ensureStep3Defaults.tsx
@@ -22,9 +22,11 @@ export function ensureStep3Defaults(
     // Then, map over the source array to ensure each object within it also has defaults.
     goals:
       src?.goals?.map(g => ({
-        id: g?.id ?? crypto.randomUUID(), // Provide a new ID for client-side keys if one doesn't exist.
+        id: g?.id ?? crypto.randomUUID(),
         name: g?.name ?? "",
-        amount: g?.amount ?? null,
+        targetAmount: g?.targetAmount ?? null,
+        targetDate: g?.targetDate ?? "",
+        amountSaved: g?.amountSaved ?? null,
       })) ?? [],
   };
 }


### PR DESCRIPTION
## Summary
- add new goal validation schema
- update savings step schema to use new sub-schema
- extend default handling for savings goals
- enhance wizard data store for new fields
- implement dynamic savings goals form with monthly projection

## Testing
- `npm ci`
- `npx jest --runInBand` *(fails: Could not locate module @context/AuthProvider)*

------
https://chatgpt.com/codex/tasks/task_e_6856e311b498832eb8e461fbe61fb3e8