### PR TITLE
Add debts wizard step

### DIFF
--- a/Frontend/src/components/organisms/overlays/wizard/SharedComponents/Menu/WizardHeading.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/SharedComponents/Menu/WizardHeading.tsx
@@ -30,7 +30,9 @@ const WizardHeading: React.FC<WizardHeadingProps> = ({ type, step }) => {
       case 3:
         return "Steg 3: Sparande";
       case 4:
-        return "Steg 4: Bekräfta";
+        return "Steg 4: Skulder";
+      case 5:
+        return "Steg 5: Bekräfta";
       default:
         return "Setup Wizard";
     }

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetDebts4/Components/Pages/SubSteps/1_Info/Info.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetDebts4/Components/Pages/SubSteps/1_Info/Info.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const Info: React.FC = () => (
+  <div className="p-4 space-y-4">
+    <h3 className="text-xl font-bold">Information</h3>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+  </div>
+);
+
+export default Info;

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetDebts4/Components/Pages/SubSteps/2_Skulder/Skulder.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetDebts4/Components/Pages/SubSteps/2_Skulder/Skulder.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const Skulder: React.FC = () => (
+  <div className="p-4 space-y-4">
+    <h3 className="text-xl font-bold">Skulder</h3>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+  </div>
+);
+
+export default Skulder;

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetDebts4/Components/Pages/SubSteps/3_SubStepConfirm/SubStepConfirm.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetDebts4/Components/Pages/SubSteps/3_SubStepConfirm/SubStepConfirm.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const SubStepConfirm: React.FC = () => (
+  <div className="p-4 space-y-4">
+    <h3 className="text-xl font-bold">Bekräfta</h3>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+  </div>
+);
+
+export default SubStepConfirm;

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetDebts4/Components/StepBudgetDebtsContainer.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetDebts4/Components/StepBudgetDebtsContainer.tsx
@@ -57,7 +57,17 @@ function getDebtsPartialData(subStep: number, allData: Step4FormValues): Partial
 }
 
 const StepBudgetDebtsContainer = forwardRef<StepBudgetDebtsContainerRef, StepBudgetDebtsContainerProps>((props, ref) => {
-  const { onSaveStepData, stepNumber, initialData = {}, onNext, onPrev, loading: parentLoading, initialSubStep } = props;
+  const {
+    onSaveStepData,
+    stepNumber,
+    initialData = {},
+    onNext,
+    onPrev,
+    loading: parentLoading,
+    initialSubStep,
+    onSubStepChange,      // ✅ Add this
+    onValidationError,    // ✅ And this
+  } = props;
   const isMobile = useMediaQuery('(max-width: 1367px)');
   const hasHydrated = useRef(false);
 
@@ -126,10 +136,9 @@ const StepBudgetDebtsContainer = forwardRef<StepBudgetDebtsContainerRef, StepBud
   const clickProgress = (d: number) => goToSub(d);
 
   useEffect(() => {
-    if (isFormHydrated) {
-      props.onSubStepChange?.(currentSub);
-    }
-  }, [currentSub, isFormHydrated, props]);
+    if (isFormHydrated) onSubStepChange?.(currentSub);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentSub, isFormHydrated]);
 
   useImperativeHandle(ref, () => ({
     validateFields: () => formMethods?.trigger() ?? Promise.resolve(false),

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetDebts4/Components/StepBudgetDebtsContainer.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetDebts4/Components/StepBudgetDebtsContainer.tsx
@@ -1,0 +1,200 @@
+import React, { useState, forwardRef, useImperativeHandle, useRef, useEffect, useCallback } from 'react';
+import { UseFormReturn, FieldErrors } from 'react-hook-form';
+import AnimatedContent from '@components/atoms/wrappers/AnimatedContent';
+import { Step4FormValues } from '@/types/Wizard/Step4FormValues';
+import { ensureStep4Defaults } from '@/utils/wizard/ensureStep4Defaults';
+import { useSaveStepData } from '@hooks/wizard/useSaveStepData';
+import { useWizardDataStore } from '@/stores/Wizard/wizardDataStore';
+import useMediaQuery from '@hooks/useMediaQuery';
+import WizardProgress from '@components/organisms/overlays/wizard/SharedComponents/Menu/WizardProgress';
+import StepCarousel from '@components/molecules/progress/StepCarousel';
+import LoadingScreen from '@components/molecules/feedback/LoadingScreen';
+import WizardFormWrapperStep4, { WizardFormWrapperStep4Ref } from './wrapper/WizardFormWrapperStep4';
+import { Info, CreditCard, ShieldCheck } from 'lucide-react';
+import InfoPage from './Pages/SubSteps/1_Info/Info';
+import SkulderPage from './Pages/SubSteps/2_Skulder/Skulder';
+import ConfirmPage from './Pages/SubSteps/3_SubStepConfirm/SubStepConfirm';
+
+export interface StepBudgetDebtsContainerRef {
+  validateFields(): Promise<boolean>;
+  getStepData(): Step4FormValues;
+  markAllTouched(): void;
+  getErrors(): FieldErrors<Step4FormValues>;
+  getCurrentSubStep(): number;
+  goPrevSub(): void;
+  goNextSub(): void;
+  hasPrevSub(): boolean;
+  hasNextSub(): boolean;
+  isSaving(): boolean;
+  hasSubSteps: () => boolean;
+  getTotalSubSteps: () => number;
+}
+
+interface StepBudgetDebtsContainerProps {
+  wizardSessionId: string;
+  onSaveStepData: (
+    step: number,
+    subStep: number,
+    data: any,
+    goingBackwards: boolean
+  ) => Promise<boolean>;
+  stepNumber: number;
+  initialData?: Partial<Step4FormValues>;
+  onNext: () => void;
+  onPrev: () => void;
+  loading: boolean;
+  initialSubStep: number;
+  onSubStepChange?: (newSub: number) => void;
+  onValidationError?: () => void;
+}
+
+function getDebtsPartialData(subStep: number, allData: Step4FormValues): Partial<Step4FormValues> {
+  switch (subStep) {
+    case 1: return { info: allData.info };
+    case 2: return { debts: allData.debts };
+    default: return {};
+  }
+}
+
+const StepBudgetDebtsContainer = forwardRef<StepBudgetDebtsContainerRef, StepBudgetDebtsContainerProps>((props, ref) => {
+  const { onSaveStepData, stepNumber, initialData = {}, onNext, onPrev, loading: parentLoading, initialSubStep } = props;
+  const isMobile = useMediaQuery('(max-width: 1367px)');
+  const hasHydrated = useRef(false);
+
+  const { setDebts } = useWizardDataStore();
+  useEffect(() => {
+    if (initialData && Object.keys(initialData).length > 0 && !hasHydrated.current) {
+      const complete = ensureStep4Defaults(initialData);
+      setDebts(complete);
+      hasHydrated.current = true;
+    }
+  }, [initialData, setDebts]);
+
+  const formWrapperRef = useRef<WizardFormWrapperStep4Ref>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [currentSub, setCurrentSub] = useState(initialSubStep || 1);
+  const [formMethods, setFormMethods] = useState<UseFormReturn<Step4FormValues> | null>(null);
+  const [isFormHydrated, setIsFormHydrated] = useState(false);
+
+  const handleFormHydration = () => setIsFormHydrated(true);
+
+  const hasSetMethods = useRef(false);
+  const handleFormWrapperRef = useCallback((instance: WizardFormWrapperStep4Ref | null) => {
+    if (instance && !hasSetMethods.current) {
+      setFormMethods(instance.getMethods());
+      hasSetMethods.current = true;
+    }
+  }, []);
+
+  const { saveStepData } = useSaveStepData<Step4FormValues>({
+    stepNumber,
+    methods: formMethods ?? undefined,
+    isMobile,
+    onSaveStepData,
+    setCurrentStep: setCurrentSub,
+    onError: () => props.onValidationError?.(),
+    getPartialDataForSubstep: getDebtsPartialData,
+  });
+
+  const totalSteps = 3;
+
+  const goToSub = async (dest: number) => {
+    const goingBack = dest < currentSub;
+    const skipValidation = goingBack;
+    setIsSaving(true);
+    const ok = await saveStepData(currentSub, dest, skipValidation, goingBack);
+    setIsSaving(false);
+    if (ok) setCurrentSub(dest);
+  };
+
+  const next = async () => {
+    if (currentSub < totalSteps) {
+      await goToSub(currentSub + 1);
+    } else {
+      onNext();
+    }
+  };
+
+  const prev = () => {
+    if (currentSub > 1) {
+      goToSub(currentSub - 1);
+    } else {
+      onPrev();
+    }
+  };
+
+  const clickProgress = (d: number) => goToSub(d);
+
+  useEffect(() => {
+    if (isFormHydrated) {
+      props.onSubStepChange?.(currentSub);
+    }
+  }, [currentSub, isFormHydrated, props]);
+
+  useImperativeHandle(ref, () => ({
+    validateFields: () => formMethods?.trigger() ?? Promise.resolve(false),
+    getStepData: () => formMethods?.getValues() ?? ensureStep4Defaults({}),
+    markAllTouched: () => formMethods?.trigger(),
+    getErrors: () => formMethods?.formState.errors ?? {},
+    getCurrentSubStep: () => currentSub,
+    goPrevSub: prev,
+    goNextSub: next,
+    hasPrevSub: () => currentSub > 1,
+    hasNextSub: () => currentSub < totalSteps,
+    isSaving: () => isSaving,
+    hasSubSteps: () => true,
+    getTotalSubSteps: () => totalSteps,
+  }));
+
+  const steps = [
+    { icon: Info, label: 'Info' },
+    { icon: CreditCard, label: 'Skulder' },
+    { icon: ShieldCheck, label: 'Bekräfta' },
+  ];
+
+  const renderSubStep = () => {
+    switch (currentSub) {
+      case 1: return <InfoPage />;
+      case 2: return <SkulderPage />;
+      case 3: return <ConfirmPage />;
+      default: return <div>All sub-steps complete!</div>;
+    }
+  };
+
+  return (
+    <WizardFormWrapperStep4
+      ref={handleFormWrapperRef}
+      onHydrationComplete={handleFormHydration}
+    >
+      {parentLoading ? (
+        <div className="absolute inset-0 z-50 flex items-center justify-center bg-white/60 backdrop-blur-sm">
+          <LoadingScreen full textColor="black" />
+        </div>
+      ) : (
+        <form className="flex flex-col h-full">
+          {isSaving && (
+            <div className="absolute inset-0 z-50 flex items-center justify-center bg-white/60 backdrop-blur-sm">
+              <LoadingScreen full={false} actionType="save" textColor="black" />
+            </div>
+          )}
+          <div className="mb-6 flex items-center justify-between">
+            <div className="flex-1 text-center">
+              {isMobile ? (
+                <StepCarousel steps={steps} currentStep={currentSub - 1} />
+              ) : (
+                <WizardProgress step={currentSub} totalSteps={totalSteps} steps={steps} adjustProgress onStepClick={clickProgress} />
+              )}
+            </div>
+          </div>
+          <div className="flex-1">
+            <AnimatedContent animationKey={String(currentSub)} triggerKey={String(currentSub)}>
+              {renderSubStep()}
+            </AnimatedContent>
+          </div>
+        </form>
+      )}
+    </WizardFormWrapperStep4>
+  );
+});
+
+export default StepBudgetDebtsContainer;

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetDebts4/Components/wrapper/WizardFormWrapperStep4.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetDebts4/Components/wrapper/WizardFormWrapperStep4.tsx
@@ -1,0 +1,59 @@
+import React, { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
+import { useForm, FormProvider, UseFormReturn, FieldErrors } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { step4Schema } from '@/schemas/wizard/StepDebts/step4Schema';
+import { Step4FormValues } from '@/types/Wizard/Step4FormValues';
+import { ensureStep4Defaults } from '@/utils/wizard/ensureStep4Defaults';
+import { useWizardDataStore } from '@/stores/Wizard/wizardDataStore';
+import useScrollToFirstError from '@/hooks/useScrollToFirstError';
+
+export interface WizardFormWrapperStep4Ref {
+  validateFields: () => Promise<boolean>;
+  getStepData: () => Step4FormValues;
+  getErrors: () => FieldErrors<Step4FormValues>;
+  getMethods: () => UseFormReturn<Step4FormValues>;
+}
+
+interface WizardFormWrapperStep4Props {
+  children: React.ReactNode;
+  onHydrationComplete?: () => void;
+}
+
+const WizardFormWrapperStep4 = forwardRef<WizardFormWrapperStep4Ref, WizardFormWrapperStep4Props>(({ children, onHydrationComplete }, ref) => {
+  const {
+    data: { debts },
+  } = useWizardDataStore();
+
+  const defaults = ensureStep4Defaults(debts as Partial<Step4FormValues>);
+
+  const methods = useForm<Step4FormValues>({
+    resolver: yupResolver(step4Schema) as any,
+    defaultValues: defaults,
+    mode: 'onBlur',
+    reValidateMode: 'onChange',
+  });
+
+  const { formState: { errors } } = methods;
+  useScrollToFirstError(errors);
+
+  const hydrated = useRef(false);
+  useEffect(() => {
+    if (!hydrated.current) {
+      methods.reset(ensureStep4Defaults(debts as Partial<Step4FormValues>));
+      hydrated.current = true;
+      onHydrationComplete?.();
+    }
+  }, [debts, methods, onHydrationComplete]);
+
+  useImperativeHandle(ref, () => ({
+    validateFields: () => methods.trigger(),
+    getStepData: () => methods.getValues(),
+    getErrors: () => methods.formState.errors,
+    getMethods: () => methods,
+  }));
+
+  return <FormProvider {...methods}>{children}</FormProvider>;
+});
+
+WizardFormWrapperStep4.displayName = 'WizardFormWrapperStep4';
+export default WizardFormWrapperStep4;

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetDebts4/StepBudgetDebts.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetDebts4/StepBudgetDebts.tsx
@@ -1,0 +1,65 @@
+import React, { forwardRef, useImperativeHandle, useRef } from 'react';
+import GlassPane from '@components/layout/GlassPane';
+import DataTransparencySection from '@components/organisms/overlays/wizard/SharedComponents/Pages/DataTransparencySection';
+import StepBudgetDebtsContainer, { StepBudgetDebtsContainerRef } from './Components/StepBudgetDebtsContainer';
+import { Step4FormValues } from '@/types/Wizard/Step4FormValues';
+import { StepBudgetDebtsRef } from '@/types/Wizard/StepBudgetDebtsRef';
+
+interface StepBudgetDebtsProps {
+  wizardSessionId: string;
+  onSaveStepData: (
+    step: number,
+    subStep: number,
+    data: any,
+    goingBackwards: boolean
+  ) => Promise<boolean>;
+  stepNumber: number;
+  initialData?: Partial<Step4FormValues>;
+  onNext: () => void;
+  onPrev: () => void;
+  loading: boolean;
+  initialSubStep: number;
+  onSubStepChange?: (newSub: number) => void;
+  onValidationError?: () => void;
+}
+
+const StepBudgetDebts = forwardRef<StepBudgetDebtsRef, StepBudgetDebtsProps>((props, ref) => {
+  const containerRef = useRef<StepBudgetDebtsContainerRef>(null);
+
+  useImperativeHandle(ref, () => ({
+    validateFields: async () => (await containerRef.current?.validateFields()) ?? false,
+    getStepData: () => containerRef.current?.getStepData() ?? {},
+    markAllTouched: () => containerRef.current?.markAllTouched(),
+    getErrors: () => containerRef.current?.getErrors() ?? {},
+    getCurrentSubStep: () => containerRef.current?.getCurrentSubStep() ?? 0,
+    goPrevSub: () => containerRef.current?.goPrevSub?.(),
+    goNextSub: () => containerRef.current?.goNextSub?.(),
+    hasPrevSub: () => containerRef.current?.hasPrevSub?.() ?? false,
+    hasNextSub: () => containerRef.current?.hasNextSub?.() ?? false,
+    isSaving: () => containerRef.current?.isSaving?.() ?? false,
+    hasSubSteps: () => true,
+  }), []);
+
+  return (
+    <div>
+      <GlassPane>
+       <StepBudgetDebtsContainer
+          ref={containerRef}
+          wizardSessionId={props.wizardSessionId}
+          onSaveStepData={props.onSaveStepData}
+          stepNumber={props.stepNumber}
+          initialData={props.initialData}
+          onNext={props.onNext}
+          onPrev={props.onPrev}
+          loading={props.loading}
+          initialSubStep={props.initialSubStep}
+          onSubStepChange={props.onSubStepChange}
+          onValidationError={props.onValidationError}
+        />
+        <DataTransparencySection />
+      </GlassPane>
+    </div>
+  );
+});
+
+export default StepBudgetDebts;

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetDebts4/StepBudgetDebts.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetDebts4/StepBudgetDebts.tsx
@@ -42,7 +42,7 @@ const StepBudgetDebts = forwardRef<StepBudgetDebtsRef, StepBudgetDebtsProps>((pr
   }), []);
 
   return (
-    <div>
+    <div key="step-budget-debts-container">
       <GlassPane>
        <StepBudgetDebtsContainer
           ref={containerRef}

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetDebts4/StepBudgetDebts.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetDebts4/StepBudgetDebts.tsx
@@ -3,6 +3,7 @@ import GlassPane from '@components/layout/GlassPane';
 import DataTransparencySection from '@components/organisms/overlays/wizard/SharedComponents/Pages/DataTransparencySection';
 import StepBudgetDebtsContainer, { StepBudgetDebtsContainerRef } from './Components/StepBudgetDebtsContainer';
 import { Step4FormValues } from '@/types/Wizard/Step4FormValues';
+import { ensureStep4Defaults } from '@/utils/wizard/ensureStep4Defaults';
 import { StepBudgetDebtsRef } from '@/types/Wizard/StepBudgetDebtsRef';
 
 interface StepBudgetDebtsProps {
@@ -28,7 +29,7 @@ const StepBudgetDebts = forwardRef<StepBudgetDebtsRef, StepBudgetDebtsProps>((pr
 
   useImperativeHandle(ref, () => ({
     validateFields: async () => (await containerRef.current?.validateFields()) ?? false,
-    getStepData: () => containerRef.current?.getStepData() ?? {},
+    getStepData: () => containerRef.current?.getStepData() ?? ensureStep4Defaults({}),
     markAllTouched: () => containerRef.current?.markAllTouched(),
     getErrors: () => containerRef.current?.getErrors() ?? {},
     getCurrentSubStep: () => containerRef.current?.getCurrentSubStep() ?? 0,

--- a/Frontend/src/hooks/wizard/useWizardInit.tsx
+++ b/Frontend/src/hooks/wizard/useWizardInit.tsx
@@ -32,12 +32,14 @@ const useWizardInit = () => {
         setIncome,
         setExpenditure,
         setSavings,
+        setDebts,
     } = useWizardDataStore(state => ({
         localStoreVersion: state.version,
         resetDataStore: state.reset,
         setIncome: state.setIncome,
         setExpenditure: state.setExpenditure,
         setSavings: state.setSavings,
+        setDebts: state.setDebts,
     }));
     
     const initWizard = useCallback(async () => {}, []);
@@ -69,6 +71,7 @@ const useWizardInit = () => {
                     if (fetchedData.income) setIncome(fetchedData.income);
                     if (fetchedData.expenditure) setExpenditure(fetchedData.expenditure);
                     if (fetchedData.savings) setSavings(fetchedData.savings);
+                    if (fetchedData.debts) setDebts(fetchedData.debts);
 
                     console.log('%c✅ The great ledger (Zustand) has been updated.', 'color: #228b22;');
 
@@ -76,6 +79,7 @@ const useWizardInit = () => {
                     if (fetchedData.income) highestStep = 1;
                     if (fetchedData.expenditure) highestStep = 2;
                     if (fetchedData.savings) highestStep = 3;
+                    if (fetchedData.debts) highestStep = 4;
                     setInitialStep(highestStep);
                     setInitialWizardSubStep(subStep);
                     console.log(`🗺️ Setting the starting point of our journey to Step ${highestStep}.`);

--- a/Frontend/src/schemas/wizard/StepDebts/step4Schema.ts
+++ b/Frontend/src/schemas/wizard/StepDebts/step4Schema.ts
@@ -1,0 +1,16 @@
+import * as yup from 'yup';
+
+export const step4Schema = yup.object({
+  info: yup.object({
+    notes: yup.string().optional(),
+  }).optional(),
+  debts: yup.array().of(
+    yup.object({
+      id: yup.string().required(),
+      name: yup.string().optional(),
+      amount: yup.number().nullable().optional(),
+    })
+  ).optional(),
+});
+
+export type Step4FormValues = yup.InferType<typeof step4Schema>;

--- a/Frontend/src/stores/Wizard/wizardDataStore.ts
+++ b/Frontend/src/stores/Wizard/wizardDataStore.ts
@@ -5,11 +5,13 @@ import { CODE_DATA_VERSION } from '@/constants/wizardVersion';
 import type { ExpenditureFormValues } from '@/types/Wizard/ExpenditureFormValues';
 import type { IncomeFormValues } from '@/types/Wizard/IncomeFormValues';
 import type { SavingsFormValues } from '@/types/Wizard/SavingsFormValues';
+import type { Step4FormValues } from '@/types/Wizard/Step4FormValues';
 
 export interface WizardData {
   income: Partial<IncomeFormValues>;
   expenditure: Partial<ExpenditureFormValues>;
   savings: Partial<SavingsFormValues>;
+  debts: Partial<Step4FormValues>;
 }
 
 export interface StepUIMetadata {
@@ -23,11 +25,12 @@ export interface WizardDataStore {
   setIncome: (d: Partial<IncomeFormValues>) => void;
   setExpenditure: (d: Partial<ExpenditureFormValues>) => void;
   setSavings: (d: Partial<SavingsFormValues>) => void;
+  setDebts: (d: Partial<Step4FormValues>) => void;
   setLastVisitedSubStep: (step: number, subStep: number) => void; // The bookmarking action
   reset: () => void;
 }
 
-const initialWizardDataState: WizardData = { income: {}, expenditure: {}, savings: {} };
+const initialWizardDataState: WizardData = { income: {}, expenditure: {}, savings: {}, debts: {} };
 const initialUIMetadata: Record<number, StepUIMetadata> = {};
 
 export const useWizardDataStore = createWithEqualityFn<WizardDataStore>()(
@@ -40,6 +43,7 @@ export const useWizardDataStore = createWithEqualityFn<WizardDataStore>()(
         setIncome: (incomeUpdate) => set((state) => ({ data: { ...state.data, income: { ...state.data.income, ...incomeUpdate } } })),
         setExpenditure: (expenditureUpdate) => set((state) => ({ data: { ...state.data, expenditure: { ...state.data.expenditure, ...expenditureUpdate } } })),
         setSavings: (savingsUpdate) => set((state) => ({ data: { ...state.data, savings: { ...state.data.savings, ...savingsUpdate } } })),
+        setDebts: (debtsUpdate) => set((state) => ({ data: { ...state.data, debts: { ...state.data.debts, ...debtsUpdate } } })),
         
 
         setLastVisitedSubStep: (step, subStep) =>

--- a/Frontend/src/types/Wizard/Step4FormValues.ts
+++ b/Frontend/src/types/Wizard/Step4FormValues.ts
@@ -1,0 +1,12 @@
+export interface DebtEntry {
+  id: string;
+  name?: string;
+  amount: number | null;
+}
+
+export interface Step4FormValues {
+  info: {
+    notes: string;
+  };
+  debts: DebtEntry[];
+}

--- a/Frontend/src/types/Wizard/StepBudgetDebtsRef.ts
+++ b/Frontend/src/types/Wizard/StepBudgetDebtsRef.ts
@@ -1,0 +1,16 @@
+import { FieldErrors } from 'react-hook-form';
+import { Step4FormValues } from './Step4FormValues';
+
+export interface StepBudgetDebtsRef {
+  validateFields(): Promise<boolean>;
+  getStepData(): Step4FormValues;
+  markAllTouched(): void;
+  getErrors(): FieldErrors<Step4FormValues>;
+  getCurrentSubStep(): number;
+  goPrevSub(): void;
+  goNextSub(): void;
+  hasPrevSub(): boolean;
+  hasNextSub(): boolean;
+  isSaving(): boolean;
+  hasSubSteps: () => boolean;
+}

--- a/Frontend/src/utils/wizard/ensureStep4Defaults.ts
+++ b/Frontend/src/utils/wizard/ensureStep4Defaults.ts
@@ -1,4 +1,4 @@
-import { Step4FormValues } from '@/schemas/wizard/StepDebts/step4Schema';
+import { Step4FormValues } from '@/types/Wizard/Step4FormValues';
 
 export function ensureStep4Defaults(src: Partial<Step4FormValues> | undefined): Step4FormValues {
   return {

--- a/Frontend/src/utils/wizard/ensureStep4Defaults.ts
+++ b/Frontend/src/utils/wizard/ensureStep4Defaults.ts
@@ -1,0 +1,14 @@
+import { Step4FormValues } from '@/schemas/wizard/StepDebts/step4Schema';
+
+export function ensureStep4Defaults(src: Partial<Step4FormValues> | undefined): Step4FormValues {
+  return {
+    info: {
+      notes: src?.info?.notes ?? '',
+    },
+    debts: (src?.debts || []).map(d => ({
+      id: d?.id ?? crypto.randomUUID(),
+      name: d?.name ?? '',
+      amount: d?.amount ?? null,
+    })),
+  } as Step4FormValues;
+}


### PR DESCRIPTION
## Summary
- add new `StepBudgetDebts` major step with three substeps
- wire new step into wizard store and navigation
- update wizard heading for new step
- include simple schema and default helpers

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862a5b17788832e84a3d915680dc53a