### PR TITLE
Add final wizard step

### DIFF
--- a/Frontend/src/components/atoms/buttons/SubmitButton.tsx
+++ b/Frontend/src/components/atoms/buttons/SubmitButton.tsx
@@ -62,6 +62,7 @@
  */
 
 import React from 'react';
+import clsx from "clsx";
 
   interface SubmitButtonProps {
     isSubmitting: boolean;
@@ -100,16 +101,26 @@ import React from 'react';
       disabled={isSubmitting}
       onClick={onClick}
       style={style}
-      className={`inline-flex items-center justify-center font-bold bg-limeGreen
-      rounded-[20px] shadow-md transition-all ease-out duration-300 border-none
-      ${sizeClasses[size]} 
-      ${
-        isSubmitting
-          ? 'bg-gray-300 text-gray-600 cursor-not-allowed'
-          : enhanceOnHover
-          ? 'hover:bg-[#001F3F] hover:text-white hover:scale-110'
-          : 'hover:bg-[limeGreen]'
-      }`}
+      className={clsx(
+        "inline-flex items-center justify-center font-bold rounded-[20px] shadow-md",
+        "transition-all ease-out duration-300 border-none whitespace-nowrap",
+        sizeClasses[size],
+
+        /* base colours (only applied when caller hasn’t overridden them) */
+        !isSubmitting && "bg-lime-500 text-slate-900",
+
+        /* disabled */
+        isSubmitting && "bg-gray-300 text-gray-600 cursor-not-allowed",
+
+        /* hover variants (when not submitting) */
+        !isSubmitting &&
+          (enhanceOnHover
+            ? "hover:bg-[#001F3F] hover:text-white hover:scale-110"
+            : "hover:bg-lime-400"),
+
+
+        className,
+      )}
     >
       {isSubmitting ? (
         <div

--- a/Frontend/src/components/layout/GlassPane.tsx
+++ b/Frontend/src/components/layout/GlassPane.tsx
@@ -3,12 +3,13 @@ import React, { ReactNode } from 'react';
 interface GlassPaneProps {
   children: ReactNode;
   withBackground?: boolean; // Optional bool to control background color
+  className?: string; // Optional className for additional styling
 }
 
-const GlassPane: React.FC<GlassPaneProps> = ({ children, withBackground = true }) => {
+const GlassPane: React.FC<GlassPaneProps> = ({ children, withBackground = true, className = "" }) => {
   const bgClass = withBackground ? 'bg-white/30' : '';
   return (
-    <div className={`text-center p-6 ${bgClass} rounded-2xl shadow-lg backdrop-blur-lg text-white`}>
+    <div className={`text-center p-6 ${bgClass} rounded-2xl shadow-lg backdrop-blur-lg text-white ${className}`}>
       {children}
     </div>
   );

--- a/Frontend/src/components/molecules/containers/WizardStepContainer.tsx
+++ b/Frontend/src/components/molecules/containers/WizardStepContainer.tsx
@@ -1,23 +1,41 @@
-import React, { ReactNode } from "react";
+import React from "react";
+import { wizardWidths } from "@/utils/wizard/ui";
+import { cn } from "@/utils/cn";         
 
 interface WizardStepContainerProps {
-  children: ReactNode;
+  children: React.ReactNode;
   className?: string;
-  disableDefaultWidth?: boolean; // optional prop to disable default width
+  /**
+   * Width: 'sm' | 'md' | 'lg'            – choose one of the presets
+   * 'responsive' (default)               – sm→lg ramp
+   * 'none'                               – let content flow full-width
+   */
+  maxWidth?: keyof typeof wizardWidths | "responsive" | "none";
 }
 
-const WizardStepContainer: React.FC<WizardStepContainerProps> = ({ children, className, disableDefaultWidth }) => {
+const WizardStepContainer: React.FC<WizardStepContainerProps> = ({
+  children,
+  className = "",
+  maxWidth = "responsive",
+}) => {
+  const widthClass =
+    maxWidth === "none"
+      ? ""
+      : maxWidth === "responsive"
+      ? "sm:max-w-md md:max-w-xl lg:max-w-4xl"
+      : wizardWidths[maxWidth];
+
   return (
     <div
-      className={`
-        space-y-4 p-6 rounded-xl shadow-md mx-auto bg-darkBlueMenuColor 
-        ${!disableDefaultWidth ? "max-w-lg" : ""} 
-        ${className || ""}
-      `}
+      className={cn(
+        "space-y-4 p-6 rounded-xl shadow-md mx-auto bg-darkBlueMenuColor",
+        widthClass,
+        className,
+      )}
     >
       {children}
     </div>
   );
 };
 
-export default WizardStepContainer;
+export default React.memo(WizardStepContainer);

--- a/Frontend/src/components/organisms/overlays/wizard/SetupWizard.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/SetupWizard.tsx
@@ -236,7 +236,7 @@ const WizardContent = (props: any) => {
                         <X size={24} />
                     </button>
                     <WizardHeading step={props.step} type="wizard" />
-                    <WizardProgress step={props.step} totalSteps={props.totalSteps} steps={props.steps} onStepClick={props.handleStepClick} />
+                    <WizardProgress step={props.step} totalSteps={props.totalSteps} steps={props.steps} onStepClick={props.handleStepClick} useBlackText={true} />
                     <AnimatedContent 
                         animationKey={String(props.step)} 
                         // The new triggerKey combines the major step and the sub-tick.
@@ -244,7 +244,7 @@ const WizardContent = (props: any) => {
                         triggerKey={`${props.step}-${props.subTick}`}
                         className="mb-6 text-center text-gray-700"
                     >
-                        <WizardStepContainer disableDefaultWidth={props.step === 2} className={props.step === 2 ? (props.isMobile ? "max-w-lg" : "max-w-4xl") : ""}>
+                        <WizardStepContainer maxWidth={props.step === 1 ? "md" : undefined}>
                             
                             {props.step === 0 ? (
                                 <StepWelcome

--- a/Frontend/src/components/organisms/overlays/wizard/SetupWizard.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/SetupWizard.tsx
@@ -15,7 +15,8 @@ import StepBudgetSavings from "@components/organisms/overlays/wizard/steps/StepB
 import { StepBudgetSavingsRef } from "@/types/Wizard/StepBudgetSavingsRef";
 import StepBudgetDebts from "@components/organisms/overlays/wizard/steps/StepBudgetDebts4/StepBudgetDebts";
 import { StepBudgetDebtsRef } from "@/types/Wizard/StepBudgetDebtsRef";
-import StepConfirmation from "@components/organisms/overlays/wizard/steps/StepConfirmation";
+import StepBudgetFinal from "@components/organisms/overlays/wizard/steps/StepBudgetFinal5/StepBudgetFinal";
+import { StepBudgetFinalRef } from "@/types/Wizard/StepBudgetFinalRef";
 import WizardFormWrapperStep1, { WizardFormWrapperStep1Ref } from '@components/organisms/overlays/wizard/steps/StepBudgetIncome1/wrapper/WizardFormWrapperStep1'; 
 import StepBudgetIncome from "@components/organisms/overlays/wizard/steps/StepBudgetIncome1/StepBudgetIncome";
 import StepExpenditure, { StepBudgetExpenditureRef } from "@components/organisms/overlays/wizard/steps/StepBudgetExpenditure2/StepBudgetExpenditure";
@@ -71,7 +72,8 @@ const SetupWizard: React.FC<SetupWizardProps> = ({ onClose }) => {
     const StepBudgetExpenditureRef = useRef<StepBudgetExpenditureRef>(null);
     const step3Ref = useRef<StepBudgetSavingsRef>(null);
     const step4Ref = useRef<StepBudgetDebtsRef>(null);
-    const stepRefs: { [key: number]: React.RefObject<any> } = { 1: step1WrapperRef, 2: StepBudgetExpenditureRef, 3: step3Ref, 4: step4Ref };
+    const step5Ref = useRef<StepBudgetFinalRef>(null);
+    const stepRefs: { [key: number]: React.RefObject<any> } = { 1: step1WrapperRef, 2: StepBudgetExpenditureRef, 3: step3Ref, 4: step4Ref, 5: step5Ref };
     const { setShowSideIncome, setShowHouseholdMembers } = useBudgetInfoDisplayFlags();
     const [subTick, setSubTick] = useState(0);
     const { setIncome, setExpenditure, setSavings, setDebts } = useWizardDataStore();
@@ -311,7 +313,21 @@ const WizardContent = (props: any) => {
                                             onValidationError={props.triggerShakeAnimation}
                                         />
                                     )}
-                                    {props.step === 5 && <StepConfirmation />}
+                                    {props.step === 5 && (
+                                        <StepBudgetFinal
+                                            ref={props.stepRefs[5]}
+                                            onNext={props.hookNextStep}
+                                            onPrev={props.hookPrevStep}
+                                            loading={props.transitionLoading || props.initLoading}
+                                            initialSubStep={props.initialSubStepForStep(5)}
+                                            onSubStepChange={props.handleSubStepChange}
+                                            wizardSessionId={props.wizardSessionId || ''}
+                                            onSaveStepData={props.handleSaveStepData}
+                                            stepNumber={5}
+                                            initialData={props.initialDataForStep(5)}
+                                            onValidationError={props.triggerShakeAnimation}
+                                        />
+                                    )}
                                 </>
                             )}
 

--- a/Frontend/src/components/organisms/overlays/wizard/SharedComponents/Buttons/WizardNavPair.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/SharedComponents/Buttons/WizardNavPair.tsx
@@ -82,6 +82,7 @@ const WizardNavPair: React.FC<WizardNavPairProps> = ({
   
   return (
     <>
+    {hasPrev && (
       <GhostIconButton
         onClick={handlePrevClick}
         disabled={disablePrev}
@@ -91,7 +92,8 @@ const WizardNavPair: React.FC<WizardNavPairProps> = ({
       >
         <IconPrev size={24} className="text-darkLimeGreen" />
       </GhostIconButton>
-
+    )}
+    {hasNext && (
       <GhostIconButton
         onClick={handleNextClick}
         disabled={disableNext}
@@ -101,6 +103,7 @@ const WizardNavPair: React.FC<WizardNavPairProps> = ({
       >
         <IconNext size={24} className="text-darkLimeGreen" />
       </GhostIconButton>
+    )}
     </>
   );
 };

--- a/Frontend/src/components/organisms/overlays/wizard/SharedComponents/Menu/WizardProgress.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/SharedComponents/Menu/WizardProgress.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { motion } from 'framer-motion';
-import clsx from 'clsx'; // I'm adding clsx for cleaner classes. If you don't have it, you can use template literals.
+import clsx from 'clsx';
 
 interface WizardStep {
   icon: React.ComponentType<{ size: string | number | undefined }>;
@@ -13,6 +13,7 @@ interface WizardProgressProps {
   steps: WizardStep[];
   onStepClick: (step: number) => void;
   adjustProgress?: boolean;
+  useBlackText?: boolean; 
 }
 
 const WizardProgress: React.FC<WizardProgressProps> = ({
@@ -21,25 +22,52 @@ const WizardProgress: React.FC<WizardProgressProps> = ({
   steps,
   onStepClick,
   adjustProgress = false,
+  useBlackText = false, 
 }) => {
   const adjustmentValue = adjustProgress ? -5 : -12;
-  
-  // If we're in development mode, we allow clicking the steps.
   const isDevMode = process.env.NODE_ENV === 'development';
 
+
+  const isLastStep = step === totalSteps;
+  const progressWidth = isLastStep
+    ? (totalSteps === 5 ? '99%' : '100%') 
+    : step > 0
+    ? `${(step / totalSteps) * 100 + adjustmentValue}%`
+    : '0%';
+
   return (
-    <div className="relative flex items-center justify-between mb-6">
-      {/* Background and progress line */}
-      <div className="absolute top-1/2 left-0 w-full h-1 bg-gray-300 z-0 transform -translate-y-1/2">
-        <motion.div
-          className="h-full bg-darkLimeGreen"
-          initial={{ width: '0%' }}
-          animate={{
-            width: step > 0 ? `${(step / totalSteps) * 100 + adjustmentValue}%` : '0%',
-          }}
-          transition={{ duration: 0.3 }}
-        />
-      </div>
+    <div
+      className={clsx(
+        'relative flex items-center mb-6',
+        totalSteps === 1 ? 'justify-center' : 'justify-between'
+      )}
+    >
+      {totalSteps > 1 && (
+        <div className="absolute top-1/2 left-0 w-full h-1 bg-gray-300 z-0 transform -translate-y-1/2">
+          {/* The main green progress bar */}
+          <motion.div
+            className="h-full bg-darkLimeGreen relative overflow-hidden"
+            initial={{ width: '0%' }}
+
+            animate={{
+              width: progressWidth,
+              scale: isLastStep ? [1, 1.02, 1] : 1,
+            }}
+            transition={{
+              width: { duration: 0.4, ease: 'easeInOut' },
+              scale: { duration: 1.5, repeat: Infinity, ease: 'easeInOut' },
+            }}
+          >
+            {/* The Glimmer of Mithril continues its duty */}
+            <motion.div
+              className="absolute inset-0 -translate-x-full bg-gradient-to-r from-transparent via-white/40 to-transparent"
+              initial={{ x: '-100%' }}
+              animate={{ x: '100%' }}
+              transition={{ repeat: Infinity, duration: 1.5, ease: 'linear' }}
+            />
+          </motion.div>
+        </div>
+      )}
 
       {/* Icons */}
       {steps.map((item, index) => {
@@ -51,29 +79,37 @@ const WizardProgress: React.FC<WizardProgressProps> = ({
           <button
             type="button"
             key={index}
-            // If we are in dev mode, the click handler works. Otherwise, it does nothing.
             onClick={isDevMode ? () => onStepClick(currentStepIndex) : undefined}
-            // The button is disabled and looks disabled in production.
             disabled={!isDevMode}
             className={clsx(
-              'relative z-10 flex flex-col items-center w-1/4 focus:outline-none',
-              // If not in dev mode, it's not a pointer. It's a rock.
+              'relative z-10 flex flex-col items-center focus:outline-none',
+              totalSteps > 1 && 'w-1/4',
               !isDevMode && 'cursor-not-allowed'
             )}
           >
             <div
-              className={`flex items-center justify-center w-10 h-10 rounded-full transition-all duration-300 ${
-                step > currentStepIndex
-                  ? 'bg-darkLimeGreen text-white'
-                  : isActive
-                  ? 'border-2 border-white/50 text-darkLimeGreen bg-white/20 backdrop-blur-sm transform scale-150 shadow-lg'
-                  : 'bg-gray-300 text-gray-700'
-              }`}
+              className={clsx(
+                'flex items-center justify-center w-10 h-10 rounded-full transition-all duration-300',
+                step > currentStepIndex && 'bg-darkLimeGreen text-white',
+                isActive && 'border-2 border-white/50 text-darkLimeGreen bg-white/20 backdrop-blur-sm transform scale-150 shadow-lg',
+                step < currentStepIndex && 'bg-gray-300 text-gray-700'
+              )}
             >
               <item.icon size={iconSize} />
             </div>
-            <span className="mt-2 text-sm font-medium text-gray-800">
-              {item.label}
+
+            <span
+                className={clsx(
+                    'mt-2 text-sm text-center transition-all',
+                    // Font weight is still determined by the active state
+                    isActive ? 'font-bold' : 'font-medium',
+
+                    isActive
+                        ? (useBlackText ? 'text-darkLimeGreen' : 'text-darkLimeGreen') // Active step color
+                        : 'text-black' // Inactive steps are always black
+                )}
+            >
+                {item.label}
             </span>
           </button>
         );

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetFinal5/Components/Pages/SubSteps/1_SubStepFinal/SubStepFinal.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetFinal5/Components/Pages/SubSteps/1_SubStepFinal/SubStepFinal.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const SubStepFinal: React.FC = () => (
+  <div className="p-4 text-center">
+    <h2 className="text-xl font-semibold mb-2">Final Step</h2>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla facilisi.</p>
+  </div>
+);
+
+export default SubStepFinal;

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetFinal5/Components/Pages/SubSteps/1_SubStepFinal/SubStepFinal.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetFinal5/Components/Pages/SubSteps/1_SubStepFinal/SubStepFinal.tsx
@@ -1,10 +1,171 @@
-import React from 'react';
+import { useWizardDataStore } from '@/stores/Wizard/wizardDataStore';
+import { SavingsGoal } from "@/types/Wizard/SavingsFormValues";
+import { Goal } from "@/types/Wizard/goal";
+import { useNavigate } from 'react-router-dom';
+import { Coins, Home, Sprout, Scale, ArrowRight } from 'lucide-react'; 
+import FinalVerdictCard from '@/components/pures/FinalVerdictCard';
+import SummaryPillarCard from '@/components/pures/SummaryPillarCard';
+import { calcMonthlyIncome, sumArray } from '@/utils/wizard/wizardHelpers';
+import { calculateTotalMonthlySavings } from '@/utils/budget/financialCalculations';
+import { summariseDebts } from "@/utils/budget/debtCalculations";
+import { useMemo } from 'react';
+import DetailedLedger from '@/components/organisms/summaries/DetailedLedger'; 
+import { cn } from '@/utils/cn';
+import { formatCurrencyParts, formatCurrency } from '@/utils/budget/currencyFormatter';
+import { SummaryGrid } from './SummaryGrid';
+import SubmitButton from '@components/atoms/buttons/SubmitButton';
 
-const SubStepFinal: React.FC = () => (
-  <div className="p-4 text-center">
-    <h2 className="text-xl font-semibold mb-2">Final Step</h2>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla facilisi.</p>
-  </div>
-);
+type StrictGoal = {
+  id: string;
+  name: string;
+  targetAmount: number;
+  amountSaved: number;
+  targetDate: string;
+};
+
+const SubStepFinal: React.FC = () => {
+    const { income, expenditure, savings, debts } = useWizardDataStore((s) => s.data);
+    const navigate = useNavigate();
+    const handleGoToDashboard = () => {
+        // This function will contain the logic to end the wizard and redirect the user
+        navigate('/dashboard'); 
+    };
+    // 1. Total Monthly Income (Spell from the Scroll of Totals)
+    const totalIncome = calcMonthlyIncome(income);
+
+    // 2. Total Monthly Expenditure (The Grand Summation Spell, also from the Scroll of Totals)
+    const totalExpenditure = sumArray([
+        expenditure.rent?.monthlyRent, expenditure.rent?.rentExtraFees, expenditure.rent?.monthlyFee, expenditure.rent?.brfExtraFees, expenditure.rent?.mortgagePayment, expenditure.rent?.houseotherCosts, expenditure.rent?.otherCosts,
+        expenditure.transport?.monthlyFuelCost, expenditure.transport?.monthlyInsuranceCost, expenditure.transport?.monthlyTotalCarCost, expenditure.transport?.monthlyTransitCost,
+        expenditure.food?.foodStoreExpenses, expenditure.food?.takeoutExpenses,
+        expenditure.fixedExpenses?.insurance, expenditure.fixedExpenses?.electricity, expenditure.fixedExpenses?.internet, expenditure.fixedExpenses?.phone, expenditure.fixedExpenses?.unionFees,
+        ...(expenditure.fixedExpenses?.customExpenses?.map((e) => e?.cost) ?? []),
+        expenditure.clothing?.monthlyClothingCost,
+        expenditure.subscriptions?.netflix, expenditure.subscriptions?.spotify, expenditure.subscriptions?.hbomax, expenditure.subscriptions?.viaplay, expenditure.subscriptions?.disneyPlus,
+        ...(expenditure.subscriptions?.customSubscriptions?.map((s) => s?.cost) ?? []),
+    ]);
+
+    
+
+    // --- The Ritual Begins ---
+    const isComplete = (g: SavingsGoal): g is StrictGoal =>
+        !!g.id &&
+        !!g.name &&
+        g.targetAmount != null &&
+        g.targetAmount > 0 && 
+        g.amountSaved != null &&
+        !!g.targetDate;
+
+
+    const calculableGoals: Goal[] = (savings.goals ?? [])
+        .filter(isComplete) 
+        .map(g => ({      
+            id: g.id,
+            name: g.name,
+            targetAmount: g.targetAmount,
+            amountSaved: g.amountSaved,
+            targetDate: new Date(g.targetDate),
+        }));
+
+    const pillarDescriptions = useMemo(() => {
+        // For the Expenditure Pillar, we find the top 3 categories
+        const expenditureCategories = [
+            { name: 'Boende', value: sumArray([expenditure.rent?.monthlyRent, expenditure.rent?.rentExtraFees, /* etc. */]) },
+            { name: 'Transport', value: sumArray([expenditure.transport?.monthlyFuelCost, /* etc. */]) },
+            { name: 'Mat', value: sumArray([expenditure.food?.foodStoreExpenses, /* etc. */]) },
+            // ... add all other main categories here ...
+        ].sort((a, b) => b.value - a.value);
+
+        const top3Expenditures = expenditureCategories.slice(0, 3).map(c => c.name).join(', ');
+
+        return {
+            income: "Från lön, sidoinkomster och andra källor i hushållet.",
+            expenditure: `Dina största utgifter är ${top3Expenditures}.`,
+            savings: `Du sparar för ${calculableGoals.length} specifika mål. Utmärkt!`,
+            debts: `Du har valt ${debts.summary?.repaymentStrategy === 'avalanche' ? 'Lavinen' : 'Snöbollen'} som din väg till skuldfrihet.`
+        };
+    }, [expenditure, calculableGoals, debts.summary?.repaymentStrategy]);
+    const goalSavings = calculateTotalMonthlySavings(calculableGoals);
+    const habitSavings = savings.habits?.monthlySavings ?? 0;
+    const totalSavings = goalSavings + habitSavings;
+    
+    const { totalMonthlyPayment: totalDebtPayments } = summariseDebts(debts.debts ?? []);
+    const finalBalance = totalIncome - totalExpenditure - totalSavings - totalDebtPayments;
+    const { number, currency } = formatCurrencyParts(finalBalance); 
+
+    return (
+        <div className="p-4 md:p-8 min-h-screen w-full">
+          <div className="max-w-xl mx-auto bg-black/30 backdrop-blur-sm/6 p-6
+                          rounded-xl mb-12 text-center shadow-lg">
+            <h1 className="text-4xl font-bold text-darkLimeGreen">
+              Grattis, du har färdig<wbr/>ställt din budget!
+            </h1>
+            <p className="mt-4 text-white/70">
+              Här är den, din hjälp att få koll på dina&nbsp;utgifter och sparande. <br />
+              Ju mer noggrant du har lagt in dina kostnader, desto mer precis blir din budget. <br />
+              Ta en titt, begrunda och agera, tillsammans når vi högre höjder!
+            </p>
+          </div>
+
+          <SummaryGrid
+            title="Per månad"
+            rows={[
+              { label: "Inkomster",       value: totalIncome },
+              { label: "Utgifter",        value: totalExpenditure },
+              { label: "Sparade",         value: totalSavings },
+              { label: "Totala skulder",  value: totalDebtPayments },
+            ]}
+            resultLabel="Resultat"
+            resultValue={finalBalance}
+          />
+            
+          <div className="space-y-12">
+              {/* I. The Final Verdict, now forged and placed! */}
+              <FinalVerdictCard balance={finalBalance} />
+              
+              {/* II. The Four Pillars will now stand! */}
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+                  <SummaryPillarCard
+                      icon={Coins}
+                      title="Inkomster"
+                      amount={totalIncome}
+                      description={pillarDescriptions.income}
+                  />
+                  <SummaryPillarCard
+                      icon={Home}
+                      title="Utgifter"
+                      amount={totalExpenditure}
+                      description={pillarDescriptions.expenditure}
+                  />
+                  <SummaryPillarCard
+                      icon={Sprout}
+                      title="Sparande"
+                      amount={totalSavings}
+                      description={pillarDescriptions.savings}
+                  />
+                  <SummaryPillarCard
+                      icon={Scale}
+                      title="Skulder"
+                      amount={totalDebtPayments}
+                      description={pillarDescriptions.debts}
+                  />
+              </div>
+
+              {/* III. The Detailed Ledger, now in its place */}
+              <DetailedLedger />
+
+              {/* Final CTA */}
+              <SubmitButton
+                isSubmitting={false}
+                label="Fortsätt din resa!"
+                size="large"
+                className="bg-darkLimeGreen text-darkBlueMenuColor"
+                enhanceOnHover
+                onClick={handleGoToDashboard}
+              />
+          </div>
+      </div>
+    );
+};
 
 export default SubStepFinal;

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetFinal5/Components/Pages/SubSteps/1_SubStepFinal/SummaryGrid.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetFinal5/Components/Pages/SubSteps/1_SubStepFinal/SummaryGrid.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { cn } from "@/utils/cn";
+import formatCurrency from "@/utils/budget/currencyFormatter";
+
+interface Row { label: string; value: number; }
+interface Props {
+  title: string;
+  rows: Row[];
+  resultLabel?: string;
+  resultValue?: number;
+}
+const SummaryRow = ({ label, value }: { label: string; value: number }) => (
+  <li className="
+        flex flex-col               /* phones: stack */
+        sm:grid sm:grid-cols-[max-content_auto] sm:items-center
+        gap-x-4 sm:gap-x-6 py-1
+      ">
+    <span className="text-xs sm:text-base font-semibold text-white/70 uppercase tracking-wider">
+      {label}
+    </span>
+    <span className="text-lg sm:text-right font-mono text-white">
+      {value.toLocaleString('sv-SE')} kr
+    </span>
+  </li>
+);
+export const SummaryGrid: React.FC<Props> = ({
+  title,
+  rows,
+  resultLabel,
+  resultValue,
+}) => (
+  <div className="mx-auto w-full max-w-sm sm:max-w-fit mb-4
+                  bg-black/30 backdrop-blur-sm/6 p-6 rounded-xl shadow-lg">
+    <div className="grid gap-y-2 sm:gap-y-1 gap-x-4 sm:gap-x-6 text-lg
+                    grid-cols-1
+                    sm:[grid-template-columns:max-content_auto]">
+
+      {/* header */}
+      <span className="col-span-full text-center text-xl font-bold text-darkLimeGreen">
+        {title}
+      </span>
+
+      {/* rows */}
+    {/* 👉 swap the old grid-for-rows for this list */}
+    <ul className="space-y-3 sm:space-y-0">
+      {rows.map(r => (
+        <SummaryRow key={r.label} label={r.label} value={r.value} />
+      ))}
+    </ul>
+
+      {/* divider + result */}
+      {resultLabel && (
+        <>
+          <hr className="col-span-full my-4 border-white/20" />
+          <span className="font-bold text-2xl text-left sm:text-right">
+            {resultLabel}
+          </span>
+          <span
+            className={cn(
+              "font-bold text-2xl text-left sm:text-right",
+              (resultValue ?? 0) < 0 ? "text-red-500" : "text-green-500",
+            )}
+          >
+            {formatCurrency(resultValue ?? 0)}
+          </span>
+        </>
+      )}
+    </div>
+  </div>
+);

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetFinal5/Components/StepBudgetFinalContainer.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetFinal5/Components/StepBudgetFinalContainer.tsx
@@ -9,6 +9,7 @@ import WizardProgress from '@components/organisms/overlays/wizard/SharedComponen
 import StepCarousel from '@components/molecules/progress/StepCarousel';
 import SubStepFinal from './Pages/SubSteps/1_SubStepFinal/SubStepFinal';
 import LoadingScreen from '@components/molecules/feedback/LoadingScreen';
+import { ShieldCheck } from 'lucide-react';
 
 export interface StepBudgetFinalContainerRef extends StepBudgetFinalRef {
   markAllTouched(): void;
@@ -41,7 +42,7 @@ const StepBudgetFinalContainer = forwardRef<StepBudgetFinalContainerRef, StepBud
   const [currentSub, setCurrentSub] = useState(initialSubStep || 1);
   const wrapperRef = useRef<WizardFormWrapperStep5Ref>(null);
 
-  const steps = [ { label: 'Slut', icon: undefined } ];
+  const steps = [ { label: 'Slut', icon: ShieldCheck } ];
   const totalSteps = 1;
 
   const next = () => {
@@ -92,7 +93,12 @@ const StepBudgetFinalContainer = forwardRef<StepBudgetFinalContainerRef, StepBud
               {isMobile ? (
                 <StepCarousel steps={steps} currentStep={0} />
               ) : (
-                <WizardProgress step={1} totalSteps={1} steps={steps} />
+                <WizardProgress
+                  step={1}
+                  totalSteps={1}
+                  steps={steps}
+                  onStepClick={() => {}} 
+                />
               )}
             </div>
           </div>

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetFinal5/Components/StepBudgetFinalContainer.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetFinal5/Components/StepBudgetFinalContainer.tsx
@@ -1,0 +1,110 @@
+import React, { useState, forwardRef, useImperativeHandle, useRef } from 'react';
+import { FieldErrors } from 'react-hook-form';
+import AnimatedContent from '@components/atoms/wrappers/AnimatedContent';
+import WizardFormWrapperStep5, { WizardFormWrapperStep5Ref } from './wrapper/WizardFormWrapperStep5';
+import useMediaQuery from '@hooks/useMediaQuery';
+import { Step5FormValues } from '@/types/Wizard/Step5FormValues';
+import { StepBudgetFinalRef } from '@/types/Wizard/StepBudgetFinalRef';
+import WizardProgress from '@components/organisms/overlays/wizard/SharedComponents/Menu/WizardProgress';
+import StepCarousel from '@components/molecules/progress/StepCarousel';
+import SubStepFinal from './Pages/SubSteps/1_SubStepFinal/SubStepFinal';
+import LoadingScreen from '@components/molecules/feedback/LoadingScreen';
+
+export interface StepBudgetFinalContainerRef extends StepBudgetFinalRef {
+  markAllTouched(): void;
+  getErrors(): FieldErrors<Step5FormValues>;
+  hasSubSteps: () => boolean;
+  getTotalSubSteps: () => number;
+}
+
+interface StepBudgetFinalContainerProps {
+  wizardSessionId: string;
+  onSaveStepData: (
+    step: number,
+    subStep: number,
+    data: any,
+    goingBackwards: boolean
+  ) => Promise<boolean>;
+  stepNumber: number;
+  initialData?: Partial<Step5FormValues>;
+  onNext: () => void;
+  onPrev: () => void;
+  loading: boolean;
+  initialSubStep: number;
+  onSubStepChange?: (newSub: number) => void;
+  onValidationError?: () => void;
+}
+
+const StepBudgetFinalContainer = forwardRef<StepBudgetFinalContainerRef, StepBudgetFinalContainerProps>((props, ref) => {
+  const { onNext, onPrev, loading: parentLoading, initialSubStep } = props;
+  const isMobile = useMediaQuery('(max-width: 1367px)');
+  const [currentSub, setCurrentSub] = useState(initialSubStep || 1);
+  const wrapperRef = useRef<WizardFormWrapperStep5Ref>(null);
+
+  const steps = [ { label: 'Slut', icon: undefined } ];
+  const totalSteps = 1;
+
+  const next = () => {
+    if (currentSub < totalSteps) {
+      setCurrentSub(currentSub + 1);
+      props.onSubStepChange?.(currentSub + 1);
+    } else {
+      onNext();
+    }
+  };
+
+  const prev = () => {
+    if (currentSub > 1) {
+      setCurrentSub(currentSub - 1);
+      props.onSubStepChange?.(currentSub - 1);
+    } else {
+      onPrev();
+    }
+  };
+
+  useImperativeHandle(ref, () => ({
+    validateFields: async () => true,
+    getStepData: () => ({} as Step5FormValues),
+    markAllTouched: () => {},
+    getErrors: () => ({} as FieldErrors<Step5FormValues>),
+    getCurrentSubStep: () => currentSub,
+    goPrevSub: prev,
+    goNextSub: next,
+    hasPrevSub: () => false,
+    hasNextSub: () => false,
+    isSaving: () => false,
+    hasSubSteps: () => false,
+    getTotalSubSteps: () => totalSteps,
+  }), [currentSub, next, prev]);
+
+  const renderSubStep = () => <SubStepFinal />;
+
+  return (
+    <WizardFormWrapperStep5 ref={wrapperRef}>
+      {parentLoading ? (
+        <div className="absolute inset-0 z-50 flex items-center justify-center bg-white/60 backdrop-blur-sm">
+          <LoadingScreen full textColor="black" />
+        </div>
+      ) : (
+        <form className="flex flex-col h-full">
+          <div className="mb-6 flex items-center justify-between">
+            <div className="flex-1 text-center">
+              {isMobile ? (
+                <StepCarousel steps={steps} currentStep={0} />
+              ) : (
+                <WizardProgress step={1} totalSteps={1} steps={steps} />
+              )}
+            </div>
+          </div>
+          <div className="flex-1">
+            <AnimatedContent animationKey="1" triggerKey="1">
+              {renderSubStep()}
+            </AnimatedContent>
+          </div>
+        </form>
+      )}
+    </WizardFormWrapperStep5>
+  );
+});
+
+export default StepBudgetFinalContainer;

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetFinal5/Components/wrapper/WizardFormWrapperStep5.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetFinal5/Components/wrapper/WizardFormWrapperStep5.tsx
@@ -1,0 +1,30 @@
+import React, { forwardRef, useImperativeHandle } from 'react';
+import { useForm, FormProvider, UseFormReturn, FieldErrors } from 'react-hook-form';
+import { Step5FormValues } from '@/types/Wizard/Step5FormValues';
+
+export interface WizardFormWrapperStep5Ref {
+  validateFields: () => Promise<boolean>;
+  getStepData: () => Step5FormValues;
+  getErrors: () => FieldErrors<Step5FormValues>;
+  getMethods: () => UseFormReturn<Step5FormValues>;
+}
+
+interface WizardFormWrapperStep5Props {
+  children: React.ReactNode;
+}
+
+const WizardFormWrapperStep5 = forwardRef<WizardFormWrapperStep5Ref, WizardFormWrapperStep5Props>(({ children }, ref) => {
+  const methods = useForm<Step5FormValues>({ defaultValues: {} as Step5FormValues });
+
+  useImperativeHandle(ref, () => ({
+    validateFields: () => Promise.resolve(true),
+    getStepData: () => methods.getValues(),
+    getErrors: () => methods.formState.errors,
+    getMethods: () => methods,
+  }));
+
+  return <FormProvider {...methods}>{children}</FormProvider>;
+});
+
+WizardFormWrapperStep5.displayName = 'WizardFormWrapperStep5';
+export default WizardFormWrapperStep5;

--- a/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetFinal5/StepBudgetFinal.tsx
+++ b/Frontend/src/components/organisms/overlays/wizard/steps/StepBudgetFinal5/StepBudgetFinal.tsx
@@ -1,0 +1,65 @@
+import React, { forwardRef, useImperativeHandle, useRef } from 'react';
+import GlassPane from '@components/layout/GlassPane';
+import DataTransparencySection from '@components/organisms/overlays/wizard/SharedComponents/Pages/DataTransparencySection';
+import StepBudgetFinalContainer, { StepBudgetFinalContainerRef } from './Components/StepBudgetFinalContainer';
+import { Step5FormValues } from '@/types/Wizard/Step5FormValues';
+import { StepBudgetFinalRef } from '@/types/Wizard/StepBudgetFinalRef';
+
+interface StepBudgetFinalProps {
+  wizardSessionId: string;
+  onSaveStepData: (
+    step: number,
+    subStep: number,
+    data: any,
+    goingBackwards: boolean
+  ) => Promise<boolean>;
+  stepNumber: number;
+  initialData?: Partial<Step5FormValues>;
+  onNext: () => void;
+  onPrev: () => void;
+  loading: boolean;
+  initialSubStep: number;
+  onSubStepChange?: (newSub: number) => void;
+  onValidationError?: () => void;
+}
+
+const StepBudgetFinal = forwardRef<StepBudgetFinalRef, StepBudgetFinalProps>((props, ref) => {
+  const containerRef = useRef<StepBudgetFinalContainerRef>(null);
+
+  useImperativeHandle(ref, () => ({
+    validateFields: async () => (await containerRef.current?.validateFields()) ?? true,
+    getStepData: () => containerRef.current?.getStepData() ?? {},
+    markAllTouched: () => containerRef.current?.markAllTouched(),
+    getErrors: () => containerRef.current?.getErrors() ?? {},
+    getCurrentSubStep: () => containerRef.current?.getCurrentSubStep() ?? 0,
+    goPrevSub: () => containerRef.current?.goPrevSub?.(),
+    goNextSub: () => containerRef.current?.goNextSub?.(),
+    hasPrevSub: () => containerRef.current?.hasPrevSub?.() ?? false,
+    hasNextSub: () => containerRef.current?.hasNextSub?.() ?? false,
+    isSaving: () => containerRef.current?.isSaving?.() ?? false,
+    hasSubSteps: () => containerRef.current?.hasSubSteps?.() ?? false,
+  }), []);
+
+  return (
+    <div>
+      <GlassPane>
+        <StepBudgetFinalContainer
+          ref={containerRef}
+          wizardSessionId={props.wizardSessionId}
+          onSaveStepData={props.onSaveStepData}
+          stepNumber={props.stepNumber}
+          initialData={props.initialData}
+          onNext={props.onNext}
+          onPrev={props.onPrev}
+          loading={props.loading}
+          initialSubStep={props.initialSubStep}
+          onSubStepChange={props.onSubStepChange}
+          onValidationError={props.onValidationError}
+        />
+        <DataTransparencySection />
+      </GlassPane>
+    </div>
+  );
+});
+
+export default StepBudgetFinal;

--- a/Frontend/src/components/organisms/summaries/DetailedLedger.tsx
+++ b/Frontend/src/components/organisms/summaries/DetailedLedger.tsx
@@ -1,0 +1,119 @@
+import React, { useState, useMemo } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { ChevronDown, ArrowRight } from 'lucide-react';
+import {
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+} from "@/components/ui/accordion"; // Assuming you have this from shadcn/ui
+import formatCurrency from '@/utils/budget/currencyFormatter';
+import { sumArray } from '@/utils/wizard/wizardHelpers';
+import { useWizardDataStore } from '@/stores/Wizard/wizardDataStore';
+
+
+const LedgerRow: React.FC<{ label: string; value: string | number | null }> = ({ label, value }) =>
+  value == null                    
+    ? null
+    : (
+      <li className="grid grid-cols-1 sm:grid-cols-[1fr_auto] gap-y-1 py-2 border-b border-slate-700/50">
+        <span className="text-white/70 truncate">{label}</span>
+        <span className="font-mono font-semibold text-white sm:text-right">
+          {typeof value === "number" ? formatCurrency(value) : value}
+        </span>
+      </li>
+    );
+
+
+    const DetailedLedger: React.FC = () => {
+        const [isOpen, setIsOpen] = useState(false);
+        const { income, expenditure, savings, debts } = useWizardDataStore((s) => s.data);
+
+        // We can reuse the detailed breakdown logic from our "wise scrolls"
+        const expenditureBreakdown = useMemo(() => {
+            // This is a simplified version; you can use the more complex one from your reference file
+            return [
+                { label: 'Boende', value: sumArray([expenditure.rent?.monthlyRent, expenditure.rent?.monthlyFee, /* etc. */]) },
+                { label: 'Transport', value: sumArray([expenditure.transport?.monthlyFuelCost, /* etc. */]) },
+                { label: 'Mat', value: sumArray([expenditure.food?.foodStoreExpenses, expenditure.food?.takeoutExpenses]) },
+                { label: 'Fasta Utgifter', value: sumArray([expenditure.fixedExpenses?.insurance, expenditure.fixedExpenses?.electricity, /* etc. */]) },
+                { label: 'Rörliga Utgifter', value: sumArray([expenditure.clothing?.monthlyClothingCost, expenditure.subscriptions?.netflix, /* etc. */]) }
+            ].filter(item => item.value > 0);
+    }, [expenditure]);
+
+    return (
+        <div className="text-center">
+            {/* The button to reveal the magic */}
+            <button
+                type="button"
+                onClick={() => setIsOpen(!isOpen)}
+                className="inline-flex items-center gap-2 text-darkLimeGreen font-semibold hover:text-lime-300 transition-colors"
+            >
+                {isOpen ? 'Dölj detaljerad summering' : 'Visa fullständig detaljsummering'}
+                <ChevronDown className={`h-5 w-5 transition-transform duration-300 ${isOpen ? 'rotate-180' : ''}`} />
+            </button>
+
+            {/* The collapsible content */}
+            <AnimatePresence>
+                {isOpen && (
+                    <motion.div
+                        initial={{ opacity: 0, height: 0 }}
+                        animate={{ opacity: 1, height: 'auto' }}
+                        exit={{ opacity: 0, height: 0 }}
+                        className="text-left mt-6 overflow-hidden"
+                    >
+                        <Accordion type="multiple" className="space-y-4">
+                            {/* Income Details */}
+                            <AccordionItem value="income" className="bg-slate-800/50 rounded-xl border-none">
+                                <AccordionTrigger className="px-6 font-bold text-white">Inkomster</AccordionTrigger>
+                                <AccordionContent className="px-6 pb-4">
+                                    <ul>
+                                        <LedgerRow label="Nettolön" value={income.netSalary ?? 0} />
+                                        <LedgerRow label="Extrainkomster" value={income.extraIncome} />
+                                    </ul>
+                                </AccordionContent>
+                            </AccordionItem>
+                            
+                            {/* Expenditure Details */}
+                            <AccordionItem value="expenditure" className="bg-slate-800/50 rounded-xl border-none">
+                                <AccordionTrigger className="px-6 font-bold text-white">Utgifter</AccordionTrigger>
+                                <AccordionContent className="px-6 pb-4">
+                                    <ul>
+                                        {expenditureBreakdown.map(item => <LedgerRow key={item.label} label={item.label} value={item.value} />)}
+                                    </ul>
+                                </AccordionContent>
+                            </AccordionItem>
+                            
+                            {/* Savings Details */}
+                            <AccordionItem value="savings" className="bg-slate-800/50 rounded-xl border-none">
+                                <AccordionTrigger className="px-6 font-bold text-white">Sparande</AccordionTrigger>
+                                <AccordionContent className="px-6 pb-4">
+                                    <ul>
+                                        <LedgerRow label="Månadssparande (vana)" value={savings.habits?.monthlySavings ?? null} />
+                                        {savings.goals?.map(goal => (
+                                            <LedgerRow key={goal.id} label={goal.name ?? 'Namnlöst mål'} value={`Mål: ${formatCurrency(goal.targetAmount)}`} />
+                                        ))}
+                                    </ul>
+                                </AccordionContent>
+                            </AccordionItem>
+
+                            {/* Debts Details */}
+                            <AccordionItem value="debts" className="bg-slate-800/50 rounded-xl border-none">
+                                <AccordionTrigger className="px-6 font-bold text-white">Skulder</AccordionTrigger>
+                                <AccordionContent className="px-6 pb-4">
+                                    <ul>
+                                        {debts.debts?.map(debt => (
+                                            <LedgerRow key={debt.id} label={debt.name ?? 'Namnlös skuld'} value={`${formatCurrency(debt.balance)} @ ${debt.apr}%`} />
+                                        ))}
+                                    </ul>
+                                </AccordionContent>
+                            </AccordionItem>
+                        </Accordion>
+                    </motion.div>
+                )}
+            </AnimatePresence>
+        </div>
+    );
+};
+
+export default DetailedLedger;

--- a/Frontend/src/components/pures/FinalVerdictCard.tsx
+++ b/Frontend/src/components/pures/FinalVerdictCard.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import clsx from 'clsx';
+import { formatCurrency, formatCurrencyParts } from "@/utils/budget/currencyFormatter";
+
+interface FinalVerdictCardProps {
+  balance: number;
+}
+
+const FinalVerdictCard: React.FC<FinalVerdictCardProps> = ({ balance }) => {
+  const isSurplus = balance >= 0;
+  const { number, currency } = formatCurrencyParts(balance);  
+
+  const wisdomText = isSurplus
+    ? `Bra jobbat kompis! Du har ett överskott på ${formatCurrency(balance)} varje månad. Använd detta överskott klokt, du vet aldrig när du behöver det.`
+    : `Dina utgifter överstiger dina intäkter med ${formatCurrency(Math.abs(balance))} varje månad. Du ska vara stolt över att du nu tar ett aktivt steg mot en bättre ekonomi, första steget är alltid det svåraste, och det har du tagit nu!`;
+
+  return (
+    <motion.div
+      className="bg-slate-800/50 rounded-2xl shadow-2xl p-6 md:p-8 text-center border border-white/10"
+      initial={{ opacity: 0, scale: 0.9 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{ duration: 0.7, ease: [0.22, 1, 0.36, 1] }}
+    >
+      <h2
+        className="text-base sm:text-lg md:text-xl lg:text-2xl font-semibold text-white/80 tracking-widest uppercase"
+      >
+        Ditt&nbsp;Månads<wbr/>resultat
+      </h2>
+
+      <p
+        className={clsx(
+          "my-2 text-2xl sm:text-3xl md:text-5xl lg:text-6xl font-bold tracking-tighter",
+          isSurplus ? "text-green-400" : "text-red-400",
+        )}
+      >
+        {number}
+        <span className="hidden md:inline">&nbsp;{currency}</span>
+      </p>
+
+      <p className="max-w-2xl mx-auto text-white/70 text-sm md:text-base">
+        {wisdomText}
+      </p>
+    </motion.div>
+  );
+};
+
+export default FinalVerdictCard;

--- a/Frontend/src/components/pures/SummaryPillarCard.tsx
+++ b/Frontend/src/components/pures/SummaryPillarCard.tsx
@@ -1,0 +1,67 @@
+import { motion } from "framer-motion";
+import clsx from "clsx";
+import { formatCurrencyParts } from "@/utils/budget/currencyFormatter";
+import { LucideProps } from "lucide-react";
+
+interface Props {
+  icon: IconType; 
+  title: string;
+  amount: number;
+  description: string;
+}
+type IconType = React.ComponentType<LucideProps>; 
+// Lucide icons are React components that accept size as a prop
+const SummaryPillarCard: React.FC<Props> = ({
+  icon: Icon,
+  title,
+  amount,
+  description,
+}) => {
+  const { number, currency } = formatCurrencyParts(amount, /* alwaysSign */ false);
+
+  return (
+    <motion.article
+      initial={{ opacity: 0, y: 15 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, amount: 0.4 }}
+      transition={{ duration: 0.5, ease: [0.22, 1, 0.36, 1] }}
+      className="bg-slate-800/40 backdrop-blur-md ring-1 ring-white/10
+                 rounded-2xl p-5 flex flex-col items-center
+                 text-center shadow-lg space-y-4 overflow-hidden"
+    >
+      <Icon size={36} className="text-darkLimeGreen shrink-0" />
+
+      <h3 className="text-base sm:text-lg font-semibold tracking-wide text-white/90">
+        {title}
+        </h3>
+
+        {/* signed amount */}
+        <div className="flex flex-col items-center leading-tight">
+        {/* big number – mobile-first scale */}
+        <span
+            className={clsx(
+            "font-bold tracking-tight",
+            "text-2xl sm:text-3xl md:text-4xl",
+            amount >= 0 ? "text-green-400" : "text-red-400",
+            )}
+        >
+            {number}
+        </span>
+
+        {/* currency token – always visible, much smaller */}
+        <span className="text-xs sm:text-sm text-white/70">
+            {currency}
+        </span>
+        </div>
+
+        <p
+        className="text-white/70 text-xs sm:text-sm line-clamp-3"
+        title={description}        /* tooltip on hover for full text */
+      >
+        {description}
+      </p>
+    </motion.article>
+  );
+};
+
+export default SummaryPillarCard;

--- a/Frontend/src/types/Wizard/Step5FormValues.ts
+++ b/Frontend/src/types/Wizard/Step5FormValues.ts
@@ -1,0 +1,1 @@
+export interface Step5FormValues {}

--- a/Frontend/src/types/Wizard/StepBudgetFinalRef.ts
+++ b/Frontend/src/types/Wizard/StepBudgetFinalRef.ts
@@ -1,0 +1,16 @@
+import { FieldErrors } from 'react-hook-form';
+import { Step5FormValues } from './Step5FormValues';
+
+export interface StepBudgetFinalRef {
+  validateFields(): Promise<boolean>;
+  getStepData(): Step5FormValues;
+  markAllTouched(): void;
+  getErrors(): FieldErrors<Step5FormValues>;
+  getCurrentSubStep(): number;
+  goPrevSub(): void;
+  goNextSub(): void;
+  hasPrevSub(): boolean;
+  hasNextSub(): boolean;
+  isSaving(): boolean;
+  hasSubSteps: () => boolean;
+}

--- a/Frontend/src/utils/budget/currencyFormatter.ts
+++ b/Frontend/src/utils/budget/currencyFormatter.ts
@@ -5,3 +5,28 @@ export default (value: number | null | undefined) => {
     maximumFractionDigits: 0,
   });
 };
+
+const baseKr = new Intl.NumberFormat("sv-SE", {
+  style:           "currency",
+  currency:        "SEK",
+  currencyDisplay: "narrowSymbol",   // “kr”
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+export const formatCurrency = (value: number) => baseKr.format(value);
+
+/**  Returns `{ number: "+12 345,67", currency: "kr" }`  */
+export const formatCurrencyParts = (
+  value: number,
+  alwaysSign = true,
+) => {
+  const abs  = Math.abs(value);
+  const sign = alwaysSign ? (value < 0 ? "-" : "+") : value < 0 ? "-" : "";
+
+  const parts = baseKr.formatToParts(abs);
+  const num   = parts.filter(p => p.type !== "currency").map(p => p.value).join("");
+  const curr  = parts.find(p => p.type === "currency")?.value ?? "";
+
+  return { number: `${sign}${num}`, currency: curr };
+};

--- a/Frontend/src/utils/cn.ts
+++ b/Frontend/src/utils/cn.ts
@@ -1,0 +1,13 @@
+import { ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+/**
+ * Combine conditional class names & let tailwind-merge
+ * resolve duplicates (e.g. "p-4 p-6" ➜ "p-6").
+ *
+ * @example
+ * <div className={cn("p-4", isError && "text-red-600")} />
+ */
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/Frontend/src/utils/wizard/ensureStep2Defaults.ts
+++ b/Frontend/src/utils/wizard/ensureStep2Defaults.ts
@@ -22,7 +22,7 @@ export function ensureStep2Defaults(
       takeoutExpenses  : src?.food?.takeoutExpenses   ?? 0,
     },
 
-    /* ---------- utilities ---------- */
+    /* ---------- utilities ---------- NOT USED AS OF NOW*/
     utilities: {
       electricity: src?.utilities?.electricity ?? 0,
       water      : src?.utilities?.water       ?? 0,

--- a/Frontend/src/utils/wizard/ui.ts
+++ b/Frontend/src/utils/wizard/ui.ts
@@ -1,0 +1,6 @@
+export const wizardWidths = {
+  sm: "max-w-md",
+  md: "max-w-xl",
+  lg: "max-w-4xl",
+};
+


### PR DESCRIPTION
## Summary
- create StepBudgetFinal step with wrapper, container, and sub step page
- add types for the final step
- wire StepBudgetFinal into SetupWizard

## Testing
- `npm ci --ignore-scripts --prefix Frontend`
- `npm test --silent --prefix Frontend` *(fails: Could not locate module @context/AuthProvider)*

------
https://chatgpt.com/codex/tasks/task_e_68675fbfc02c832e8663b321a6e9dbff