### PR TITLE
refactor(database): Centralize schema management for Docker

### DIFF
--- a/Backend/Infrastructure/Data/SqlCode/MariaDB/BudgetTables/CreateBudgetTables.sql
+++ b/Backend/Infrastructure/Data/SqlCode/MariaDB/BudgetTables/CreateBudgetTables.sql
@@ -1,3 +1,10 @@
+-- ##################################################################
+-- # DEPRECATED - DO NOT USE
+-- ##################################################################
+-- # This script is no longer maintained.
+-- # The canonical database schema is now managed by Docker initialization.
+-- # See: /database/init/01-full-schema.sql
+-- ##################################################################
 
 -- This script creates the necessary tables for the SteenBudgetSystem application related to 
 -- budget managenent

--- a/Backend/Infrastructure/Data/SqlCode/MariaDB/CreateTables.sql
+++ b/Backend/Infrastructure/Data/SqlCode/MariaDB/CreateTables.sql
@@ -1,3 +1,11 @@
+-- ##################################################################
+-- # DEPRECATED - DO NOT USE
+-- ##################################################################
+-- # This script is no longer maintained.
+-- # The canonical database schema is now managed by Docker initialization.
+-- # See: /database/init/01-full-schema.sql
+-- ##################################################################
+
 
 -- This script creates the necessary tables for the SteenBudgetSystem application related to 
 -- user management and wizard functionality.

--- a/Backend/Infrastructure/Data/SqlCode/MariaDB/CreateUser.sql
+++ b/Backend/Infrastructure/Data/SqlCode/MariaDB/CreateUser.sql
@@ -1,3 +1,9 @@
+-- ##################################################################
+-- # DEPRECATED - DO NOT USE
+-- ##################################################################
+-- # This script is no longer maintained.
+-- ##################################################################
+
 -- Prod user for the SteenBudgetSystem database
 GRANT ALL PRIVILEGES ON SteenBudgetSystemPROD.* TO 'admin'@'192.168.50.%' IDENTIFIED BY 'your_admin_password';
 /*The above is fine well the project is in active development*/

--- a/database/init/01-full-schema.sql
+++ b/database/init/01-full-schema.sql
@@ -1,0 +1,216 @@
+-- ##################################################################
+-- # SECTION 1: USER AND AUTHENTICATION TABLES
+-- ##################################################################
+
+-- Create User table
+CREATE TABLE IF NOT EXISTS User (
+    Id INT AUTO_INCREMENT PRIMARY KEY,
+    Persoid BINARY(16) NOT NULL UNIQUE,
+    Firstname VARCHAR(50) NOT NULL,
+    LastName VARCHAR(50) NOT NULL,
+    Email VARCHAR(100) NOT NULL UNIQUE,
+    EmailConfirmed BOOLEAN,
+    Password VARCHAR(100) NOT NULL,
+    roles VARCHAR(20) NOT NULL,
+    Locked BOOLEAN DEFAULT FALSE,
+    LockoutUntil DATETIME,
+    FirstLogin BOOLEAN DEFAULT TRUE,
+    CreatedBy VARCHAR(50) NOT NULL,
+    CreatedTime DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    LastUpdatedTime DATETIME
+);
+
+-- Create ErrorLog table
+CREATE TABLE IF NOT EXISTS ErrorLog (
+    LogId INT AUTO_INCREMENT PRIMARY KEY,
+    ErrorMessage TEXT,
+    Caller VARCHAR(100),
+    UserInput TEXT,
+    SubmittedBy VARCHAR(100),
+    CreatedBy VARCHAR(50) NOT NULL,
+    CreatedTime DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Create VerificationToken table
+CREATE TABLE IF NOT EXISTS VerificationToken (
+    Id INT AUTO_INCREMENT PRIMARY KEY,
+    PersoId BINARY(16),
+    Token CHAR(36) NOT NULL UNIQUE,
+    TokenExpiryDate DATETIME NOT NULL,
+    CreatedBy VARCHAR(50) NOT NULL,
+    CreatedTime DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT FK_VerificationToken_User FOREIGN KEY (PersoId) REFERENCES User(PersoId) ON DELETE CASCADE
+);
+
+-- Create RefreshTokens table
+CREATE TABLE RefreshTokens (
+    TokenId              BINARY(16)   NOT NULL PRIMARY KEY,
+    Persoid              BINARY(16)   NOT NULL,
+    SessionId            BINARY(16)   NOT NULL,
+    HashedToken          VARCHAR(255) NOT NULL,
+    AccessTokenJti       VARCHAR(50)  NOT NULL,
+    ExpiresRollingUtc    DATETIME     NOT NULL,
+    ExpiresAbsoluteUtc   DATETIME     NOT NULL,
+    RevokedUtc           DATETIME     NULL,
+    Status               INT          NOT NULL,
+    IsPersistent         BOOLEAN      NOT NULL DEFAULT FALSE,
+    DeviceId             VARCHAR(255),
+    UserAgent            VARCHAR(255),
+    CreatedUtc           DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT FK_RefreshTokens_User FOREIGN KEY (Persoid) REFERENCES User(Persoid) ON DELETE CASCADE,
+    UNIQUE KEY UK_Hashed (HashedToken),
+    UNIQUE KEY ux_user_session (Persoid, SessionId)
+) ENGINE = InnoDB;
+
+-- Create UserVerificationTracking table
+CREATE TABLE UserVerificationTracking (
+    Id INT PRIMARY KEY AUTO_INCREMENT,
+    PersoId BINARY(16) NOT NULL,
+    LastResendRequestTime DATETIME,
+    DailyResendCount INT DEFAULT 0,
+    LastResendRequestDate DATE,
+    CreatedAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+    UpdatedAt DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT FK_UserVerificationTracking_User FOREIGN KEY (PersoId) REFERENCES User(PersoId) ON DELETE CASCADE
+);
+
+-- ##################################################################
+-- # SECTION 2: CORE BUDGET TABLES
+-- ##################################################################
+
+CREATE TABLE Budget (
+    Id                  BINARY(16)    NOT NULL PRIMARY KEY,
+    Persoid             BINARY(16)    NOT NULL,
+    DebtRepaymentStrategy VARCHAR(50) NULL,
+    CreatedAt           DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UpdatedAt           DATETIME      NULL ON UPDATE CURRENT_TIMESTAMP,
+    CreatedByUserId     BINARY(16)    NOT NULL,
+    UpdatedByUserId     BINARY(16)    NULL,
+    CONSTRAINT FK_Budget_User FOREIGN KEY (Persoid) REFERENCES User(Persoid) ON DELETE CASCADE,
+    INDEX IX_Budget_Persoid (Persoid) -- (INDEX ADDED FOR PERFORMANCE)
+) ENGINE=InnoDB;
+
+CREATE TABLE Income (
+    Id               BINARY(16)    NOT NULL PRIMARY KEY,
+    BudgetId         BINARY(16)    NOT NULL,
+    NetSalaryMonthly DECIMAL(18,2) NOT NULL DEFAULT 0,
+    SalaryFrequency  INT           NOT NULL,
+    CreatedAt        DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UpdatedAt        DATETIME      NULL ON UPDATE CURRENT_TIMESTAMP,
+    CreatedByUserId  BINARY(16)    NOT NULL,
+    UpdatedByUserId  BINARY(16)    NULL,
+    CONSTRAINT FK_Income_Budget FOREIGN KEY (BudgetId) REFERENCES Budget(Id) ON DELETE CASCADE,
+    INDEX IX_Income_BudgetId (BudgetId) -- (INDEX ADDED FOR PERFORMANCE)
+) ENGINE=InnoDB;
+
+CREATE TABLE IncomeSideHustle (
+    Id            BINARY(16)    NOT NULL PRIMARY KEY,
+    IncomeId      BINARY(16)    NOT NULL,
+    Name          VARCHAR(255)  NOT NULL,
+    IncomeMonthly DECIMAL(18,2) NOT NULL DEFAULT 0,
+    Frequency     INT           NOT NULL,
+    CreatedAt     DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UpdatedAt     DATETIME      NULL ON UPDATE CURRENT_TIMESTAMP,
+    CreatedByUserId BINARY(16)  NOT NULL,
+    UpdatedByUserId BINARY(16)  NULL,
+    CONSTRAINT FK_IncomeSideHustle_Income FOREIGN KEY (IncomeId) REFERENCES Income(Id) ON DELETE CASCADE,
+    INDEX IX_IncomeSideHustle_IncomeId (IncomeId) -- (INDEX ADDED FOR PERFORMANCE)
+) ENGINE=InnoDB;
+
+CREATE TABLE ExpenseCategory (
+    Id   BINARY(16)   NOT NULL PRIMARY KEY,
+    Name VARCHAR(100) NOT NULL UNIQUE
+) ENGINE=InnoDB;
+
+INSERT INTO ExpenseCategory (Id, Name) VALUES
+(UNHEX(REPLACE('2a9a1038-6ff1-4f2b-bd73-f2b9bb3f4c21', '-', '')), 'Rent'),
+(UNHEX(REPLACE('5d5c51aa-9f05-4d4c-8ff1-0a61d6c9cc10', '-', '')), 'Food'),
+(UNHEX(REPLACE('5eb2896c-59f9-4a18-8c84-4c2a1659de80', '-', '')), 'Transport'),
+(UNHEX(REPLACE('e47e5c5d-4c97-4d87-89aa-e7a86b8f5ac0', '-', '')), 'Clothing'),
+(UNHEX(REPLACE('8aa1d1b8-5b70-4fde-9e3f-b60dc4bfc900', '-', '')), 'FixedExpense'),
+(UNHEX(REPLACE('9a3fe5f3-9fc4-4cc0-93d9-1a2ab9f7a5c4', '-', '')), 'Subscription'),
+(UNHEX(REPLACE('f9f68c35-2f9b-4a8c-9faa-6f5212d3e6d2', '-', '')), 'Other');
+
+CREATE TABLE ExpenseItem (
+    Id              BINARY(16)    NOT NULL PRIMARY KEY,
+    BudgetId        BINARY(16)    NOT NULL,
+    CategoryId      BINARY(16)    NOT NULL,
+    Name            VARCHAR(255)  NOT NULL,
+    AmountMonthly   DECIMAL(18,2) NOT NULL DEFAULT 0,
+    CreatedAt       DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UpdatedAt       DATETIME      NULL ON UPDATE CURRENT_TIMESTAMP,
+    CreatedByUserId BINARY(16)    NOT NULL,
+    UpdatedByUserId BINARY(16)    NULL,
+    CONSTRAINT FK_ExpenseItem_Budget    FOREIGN KEY (BudgetId)   REFERENCES Budget(Id) ON DELETE CASCADE,
+    CONSTRAINT FK_ExpenseItem_Category  FOREIGN KEY (CategoryId) REFERENCES ExpenseCategory(Id) ON DELETE RESTRICT,
+    INDEX IX_ExpenseItem_BudgetId (BudgetId), -- (INDEX ADDED FOR PERFORMANCE)
+    INDEX IX_ExpenseItem_CategoryId (CategoryId) -- (INDEX ADDED FOR PERFORMANCE)
+) ENGINE=InnoDB;
+
+CREATE TABLE Savings (
+    Id             BINARY(16)    NOT NULL PRIMARY KEY,
+    BudgetId       BINARY(16)    NOT NULL,
+    MonthlySavings DECIMAL(18,2) NOT NULL DEFAULT 0,
+    CreatedAt      DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UpdatedAt      DATETIME      NULL ON UPDATE CURRENT_TIMESTAMP,
+    CreatedByUserId BINARY(16)   NOT NULL,
+    UpdatedByUserId BINARY(16)   NULL,
+    CONSTRAINT FK_Savings_Budget FOREIGN KEY (BudgetId) REFERENCES Budget(Id) ON DELETE CASCADE,
+    INDEX IX_Savings_BudgetId (BudgetId) -- (INDEX ADDED FOR PERFORMANCE)
+) ENGINE=InnoDB;
+
+CREATE TABLE SavingsGoal (
+    Id           BINARY(16)    NOT NULL PRIMARY KEY,
+    SavingsId    BINARY(16)    NOT NULL,
+    Name         VARCHAR(255)  NULL,
+    TargetAmount DECIMAL(18,2) NULL,
+    TargetDate   DATE          NULL,
+    AmountSaved  DECIMAL(18,2) NULL,
+    CreatedAt    DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UpdatedAt    DATETIME      NULL ON UPDATE CURRENT_TIMESTAMP,
+    CreatedByUserId BINARY(16) NOT NULL,
+    UpdatedByUserId BINARY(16) NULL,
+    CONSTRAINT FK_SavingsGoal_Savings FOREIGN KEY (SavingsId) REFERENCES Savings(Id) ON DELETE CASCADE,
+    INDEX IX_SavingsGoal_SavingsId (SavingsId) -- (INDEX ADDED FOR PERFORMANCE)
+) ENGINE=InnoDB;
+
+CREATE TABLE Debt (
+    Id              BINARY(16)    NOT NULL PRIMARY KEY,
+    BudgetId        BINARY(16)    NOT NULL,
+    Name            VARCHAR(255)  NOT NULL,
+    Type            VARCHAR(50)   NOT NULL,
+    Balance         DECIMAL(18,2) NOT NULL,
+    Apr             DECIMAL(18,2) NOT NULL,
+    CreatedAt       DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UpdatedAt       DATETIME      NULL ON UPDATE CURRENT_TIMESTAMP,
+    CreatedByUserId BINARY(16)    NOT NULL,
+    UpdatedByUserId BINARY(16)    NULL,
+    CONSTRAINT FK_Debt_Budget FOREIGN KEY (BudgetId) REFERENCES Budget(Id) ON DELETE CASCADE,
+    INDEX IX_Debt_BudgetId (BudgetId) -- (INDEX ADDED FOR PERFORMANCE)
+) ENGINE=InnoDB;
+
+-- ##################################################################
+-- # SECTION 3: WIZARD TABLES
+-- ##################################################################
+
+CREATE TABLE WizardSession (
+    WizardSessionId BINARY(16) NOT NULL PRIMARY KEY,
+    Persoid BINARY(16) NOT NULL,
+    CurrentStep INT NOT NULL DEFAULT 0,
+    CreatedAt DATETIME NOT NULL DEFAULT UTC_TIMESTAMP(),
+    UpdatedAt DATETIME NOT NULL DEFAULT UTC_TIMESTAMP(),
+    UNIQUE KEY UK_Persoid (Persoid),
+    CONSTRAINT FK_WizardSession_User FOREIGN KEY (Persoid) REFERENCES User(Persoid) ON DELETE CASCADE -- (FK ADDED FOR INTEGRITY)
+) ENGINE=InnoDB;
+
+CREATE TABLE WizardStep (
+    WizardSessionId BINARY(16) NOT NULL,
+    StepNumber INT NOT NULL,
+    SubStep INT NOT NULL,
+    StepData TEXT NOT NULL,
+    DataVersion INT NOT NULL,
+    CreatedBy VARCHAR(50) NOT NULL,
+    CreatedTime DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (WizardSessionId, StepNumber, SubStep),
+    CONSTRAINT FK_WizardStep_WizardSession FOREIGN KEY (WizardSessionId) REFERENCES WizardSession(WizardSessionId) ON DELETE CASCADE
+) ENGINE=InnoDB;


### PR DESCRIPTION
- **Unified Schema:** Merged all user, auth, and budget-related CREATE TABLE statements into a single, ordered script: /database/init/01-full-schema.sql. This establishes a single source of truth for the entire database structure.
- **Docker Integration:** This new script is now used by the MariaDB Docker entrypoint for fully automated, repeatable database initialization.
- **Deprecation:** Added clear notices to all old manual setup scripts, marking them as deprecated and pointing developers to the new canonical file.