### PR TITLE
feat(tools): add dev-only user seeding CLI + compose job; fix Users c…

### DIFF
--- a/Backend.Tools/Backend.Tools.csproj
+++ b/Backend.Tools/Backend.Tools.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    
+    <EnableDefaultCompileItems>true</EnableDefaultCompileItems>
+    <UserSecretsId>2703b779-1485-420b-9231-5fb496af1a0b</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Backend\Backend.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MediatR" Version="13.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.8" /> <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" /> <PackageReference Include="MySqlConnector" Version="2.4.0" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+  </ItemGroup>
+
+</Project>

--- a/Backend.Tools/CliUnitOfWork.cs
+++ b/Backend.Tools/CliUnitOfWork.cs
@@ -1,0 +1,80 @@
+using System.Data;
+using System.Data.Common; // Use this namespace for DbConnection/DbTransaction
+using Backend.Application.Abstractions.Infrastructure.Data;
+
+public sealed class CliUnitOfWork : IUnitOfWork
+{
+    private readonly DbConnection _connection;
+    private DbTransaction? _transaction;
+    private bool _disposed;
+
+    public CliUnitOfWork(DbConnection connection) => _connection = connection;
+
+    public DbConnection? Connection => _connection;
+    public DbTransaction? Transaction => _transaction;
+    public bool IsInTransaction => _transaction is not null;
+
+    public async Task BeginTransactionAsync(CancellationToken ct = default)
+    {
+        if (IsInTransaction)
+        {
+            // Already in a transaction, do nothing.
+            return;
+        }
+
+        if (_connection.State == ConnectionState.Closed)
+        {
+            await _connection.OpenAsync(ct);
+        }
+
+        _transaction = await _connection.BeginTransactionAsync(ct);
+    }
+
+    public async Task CommitAsync(CancellationToken ct = default)
+    {
+        if (_transaction is null)
+        {
+            // No transaction to commit.
+            return;
+        }
+
+        await _transaction.CommitAsync(ct);
+        await DisposeTransactionAsync();
+    }
+
+    public async Task RollbackAsync(CancellationToken ct = default)
+    {
+        if (_transaction is null)
+        {
+            // No transaction to roll back.
+            return;
+        }
+
+        await _transaction.RollbackAsync(ct);
+        await DisposeTransactionAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        // If the UoW is disposed with an active transaction, it must be rolled back.
+        if (_transaction is not null)
+        {
+            await _transaction.RollbackAsync();
+            await DisposeTransactionAsync();
+        }
+
+        await _connection.DisposeAsync();
+    }
+
+    private async Task DisposeTransactionAsync()
+    {
+        if (_transaction is not null)
+        {
+            await _transaction.DisposeAsync();
+            _transaction = null;
+        }
+    }
+}

--- a/Backend.Tools/CreateUserCliCommand.cs
+++ b/Backend.Tools/CreateUserCliCommand.cs
@@ -1,0 +1,51 @@
+using System.CommandLine;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Backend.Application.Features.Commands.Auth.Register;
+using Backend.Domain.Shared;
+using System.CommandLine.Invocation;
+
+public sealed class CreateUserCliCommand : Command
+{
+    private readonly IServiceProvider _sp;
+
+    public CreateUserCliCommand(IServiceProvider sp)
+        : base("create-user", "Creates a user for seeding/admin.")
+    {
+        _sp = sp;
+
+        var email = new System.CommandLine.Option<string>("--email", "Email") { IsRequired = true };
+        var password = new System.CommandLine.Option<string>("--password", "Password") { IsRequired = true };
+
+        AddOption(email);
+        AddOption(password);
+
+        this.SetHandler(async (string email, string password) =>
+                await Handle(email, password),
+            email, password);
+    }
+
+    private async Task Handle(string email, string password)
+    {
+        Console.WriteLine($"--> Creating user: {email} ...");
+
+        await using var scope = _sp.CreateAsyncScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+        var cmd = new RegisterUserCommand(
+            FirstName: "Seeded",
+            LastName: "User",
+            Email: email,
+            Password: password,
+            CaptchaToken: "",
+            Honeypot: null
+        )
+        { IsSeedingOperation = true };
+
+        Result result = await mediator.Send(cmd);
+
+        Console.WriteLine(result.IsSuccess
+            ? "--> User created successfully."
+            : $"--> Error: {result.Error}");
+    }
+}

--- a/Backend.Tools/Program.cs
+++ b/Backend.Tools/Program.cs
@@ -1,0 +1,91 @@
+﻿using System.CommandLine;
+using MediatR;
+using Backend.Application;
+using Backend.Application.Abstractions.Infrastructure.Security;
+using Backend.Domain.Shared;
+using Backend.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Backend.Application.Features.Commands.Auth.Register;
+using Backend.Application.Abstractions.Infrastructure.Data;
+using MySqlConnector;
+
+var host = Host.CreateDefaultBuilder(args)
+    // console tool: don't validate the whole web graph
+    .UseDefaultServiceProvider((ctx, o) =>
+    {
+        o.ValidateOnBuild = false;
+        o.ValidateScopes = false;
+    })
+    .ConfigureServices((ctx, services) =>
+    {
+        services
+            .AddApplicationServices(ctx.Configuration)
+            .AddInfrastructureServices(ctx.Configuration, isProduction: false);
+
+        // CLI: bypass CAPTCHA
+        services.RemoveAll<IRecaptchaService>();
+        services.AddSingleton<IRecaptchaService, NoopRecaptchaValidator>();
+
+        // CLI: override the DB connection with a user-provided connection string
+        services.RemoveAll<IUnitOfWork>();      // <— override the UoW the repos actually use
+        services.AddScoped<IUnitOfWork>(sp =>
+        {
+            var cfg = ctx.Configuration;
+            var cs =
+                cfg["DatabaseSettings:ConnectionString"] ??
+                cfg["DATABASESETTINGS__CONNECTIONSTRING"] ??
+                cfg["ConnectionStrings:Default"];
+
+            if (string.IsNullOrWhiteSpace(cs))
+                throw new InvalidOperationException(
+                    "DB connection string missing for Backend.Tools. Provide user-secret DatabaseSettings:ConnectionString or env DATABASESETTINGS__CONNECTIONSTRING.");
+
+            return new CliUnitOfWork(new MySqlConnection(cs));
+        });
+    })
+
+    .Build();
+
+var emailOpt = new Option<string>("--email") { IsRequired = true };
+var passOpt = new Option<string>("--password") { IsRequired = true };
+var firstOpt = new Option<string>("--first", () => "Seeded");
+var lastOpt = new Option<string>("--last", () => "User");
+var suppress = new Option<bool>("--suppress-notify", () => true);
+
+var cmd = new RootCommand("Admin tools: user seeding");
+cmd.SetHandler(async (string email, string password, string first, string last, bool sup) =>
+{
+    await using var scope = host.Services.CreateAsyncScope();
+    var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+    var register = new RegisterUserCommand(
+        FirstName: first,
+        LastName: last,
+        Email: email,
+        Password: password,
+        CaptchaToken: "",   // ignored by NoopRecaptchaValidator
+        Honeypot: null
+    )
+    {
+        IsSeedingOperation = true
+    };
+
+    Result r = await mediator.Send(register);
+    Console.WriteLine(r.IsSuccess ? "OK" : r.Error.ToString());
+}, emailOpt, passOpt, firstOpt, lastOpt, suppress);
+
+cmd.AddOption(emailOpt);
+cmd.AddOption(passOpt);
+cmd.AddOption(firstOpt);
+cmd.AddOption(lastOpt);
+cmd.AddOption(suppress);
+
+return await cmd.InvokeAsync(args);
+
+// --- CLI-only no-op CAPTCHA service ---
+public sealed class NoopRecaptchaValidator : IRecaptchaService
+{
+    public Task<bool> ValidateTokenAsync(string token) => Task.FromResult(true);
+}

--- a/Backend/Application/DTO/User/UserLoginDto.cs
+++ b/Backend/Application/DTO/User/UserLoginDto.cs
@@ -4,12 +4,8 @@ namespace Backend.Application.DTO.User
 {
     public class UserLoginDto
     {
-        [Required]
         public required string Email { get; set; }
-
-        [Required]
         public required string Password { get; set; }
-        [Required]
         public required string CaptchaToken { get; set; }
         public bool RememberMe { get; set; }
     }

--- a/Backend/Application/DependencyInjection.cs
+++ b/Backend/Application/DependencyInjection.cs
@@ -1,0 +1,60 @@
+// Third-party packages
+using FluentValidation;
+
+using Backend.Application.Features.Wizard.FinalizeWizard.Processors;
+using Backend.Application.Options.Email;
+using Backend.Application.Options.Auth;
+using Backend.Application.Options.URL;
+using Backend.Application.Validators;
+using Backend.Application.Mappings;
+using Mapster;
+namespace Backend.Application;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddApplicationServices(this IServiceCollection services, IConfiguration configuration)
+    {
+
+        // Settings Registration
+        services.AddOptions<EmailRateLimitOptions>()
+            .Bind(configuration.GetSection("EmailRateLimit"))
+            .ValidateDataAnnotations().ValidateOnStart();
+        services.AddOptions<AppUrls>()
+            .Bind(configuration.GetSection("AppUrls"))
+            .ValidateDataAnnotations().ValidateOnStart();
+        services.AddOptions<VerificationTokenOptions>()
+            .Bind(configuration.GetSection("VerificationToken"))
+            .ValidateDataAnnotations().ValidateOnStart();
+        services.AddOptions<AuthLockoutOptions>()
+            .BindConfiguration("AuthLockout")
+            .ValidateDataAnnotations().ValidateOnStart();
+
+        // MediatR: register handlers by assembly + add UoW behavior
+        services.AddMediatR(cfg =>
+        {
+            cfg.RegisterServicesFromAssemblies(
+                typeof(Backend.Application.Features.Authentication.Login.LoginCommandHandler).Assembly
+            // add more assemblies if you have handlers elsewhere
+            );
+            cfg.AddOpenBehavior(typeof(UnitOfWorkPipelineBehavior<,>)); // applies to all TRequest that match the constraint
+        });
+
+        // Validators
+        services.AddValidatorsFromAssemblyContaining<UserValidator>();
+        services.AddValidatorsFromAssemblyContaining<IncomeValidator>();
+
+        // Register global type adapter config
+        var cfg = TypeAdapterConfig.GlobalSettings;
+        UserMappings.Register(cfg);
+
+        // Wizard Step Processors
+        services.AddScoped<IWizardStepProcessor, IncomeStepProcessor>();
+        services.AddScoped<IWizardStepProcessor, ExpenseStepProcessor>();
+        services.AddScoped<IWizardStepProcessor, SavingsStepProcessor>();
+
+        //Wizard Validation
+        services.AddValidatorsFromAssemblyContaining<IncomeValidator>();
+
+        return services;
+    }
+}

--- a/Backend/Application/Features/Authentication/Login/LoginCommandHandler.cs
+++ b/Backend/Application/Features/Authentication/Login/LoginCommandHandler.cs
@@ -10,6 +10,7 @@ using Backend.Application.DTO.Auth;
 using Backend.Application.Abstractions.Infrastructure.System;
 using Backend.Infrastructure.Entities.Tokens;
 using Backend.Infrastructure.Security;
+using Backend.Application.Features.Wizard.FinalizeWizard.Processors.Helpers;
 
 namespace Backend.Application.Features.Authentication.Login;
 
@@ -59,6 +60,7 @@ public sealed class LoginCommandHandler : IRequestHandler<LoginCommand, Result<A
         if (!(allowTestEmails && isTestEmail) && !await _recaptcha.ValidateTokenAsync(c.CaptchaToken))
         {
             return Result.Failure<AuthResult>(UserErrors.InvalidCaptcha);
+            //return Result.Failure<AuthResult>(UserErrors.InvalidCaptcha);
         }
 
         // 2) Normalize + load + lockout

--- a/Backend/Application/Features/Authentication/VerifyEmail/VerifyEmailCommandHandler.cs
+++ b/Backend/Application/Features/Authentication/VerifyEmail/VerifyEmailCommandHandler.cs
@@ -47,7 +47,7 @@ public sealed class VerifyEmailCommandHandler : IRequestHandler<VerifyEmailComma
             return Result.Failure(UserErrors.EmailAlreadyVerified);
 
         // 4) Confirm (only if not already confirmed)
-        var ok = await _users.ConfirmUserEmailAsync(user.PersoId, ct); // SQL: ... SET EmailConfirmed=1 WHERE PersoId=@Id AND EmailConfirmed=0
+        var ok = await _users.ConfirmUserEmailAsync(user.PersoId, ct);
         if (!ok)
         {
             _log.LogError("Failed to confirm email for PersoId {PersoId}", user.PersoId);

--- a/Backend/Application/Features/Register/RegisterUserCommand.cs
+++ b/Backend/Application/Features/Register/RegisterUserCommand.cs
@@ -18,4 +18,7 @@ public record RegisterUserCommand(
     string Password,
     string CaptchaToken,
     string? Honeypot
-) : ICommand<Result>;
+) : ICommand<Result>
+{
+    public bool IsSeedingOperation { get; init; } = false;
+}

--- a/Backend/Common/Services/NoopRecaptchaValidator.cs
+++ b/Backend/Common/Services/NoopRecaptchaValidator.cs
@@ -1,0 +1,9 @@
+
+
+namespace Backend.Application.Abstractions.Infrastructure.Security;
+
+public sealed class NoopRecaptchaValidator : IRecaptchaService
+{
+    public Task<bool> ValidateTokenAsync(string token)
+        => Task.FromResult(true);
+}

--- a/Backend/Infrastructure/Data/Sql/Helpers/UnitOfWork.cs
+++ b/Backend/Infrastructure/Data/Sql/Helpers/UnitOfWork.cs
@@ -42,7 +42,7 @@ public sealed class UnitOfWork : IUnitOfWork
         if (_conn.State != ConnectionState.Open)
             await _conn.OpenAsync(ct).ConfigureAwait(false);
 
-        _tx = await _conn.BeginTransactionAsync(IsolationLevel.ReadCommitted, ct).ConfigureAwait(false);
+        _tx = await _conn.BeginTransactionAsync(IsolationLevel.RepeatableRead, ct).ConfigureAwait(false);
         _txDepth = 1;
         _log.LogDebug("UoW: BEGIN (depth=1)");
     }

--- a/Backend/Infrastructure/DependencyInjection.cs
+++ b/Backend/Infrastructure/DependencyInjection.cs
@@ -1,0 +1,136 @@
+using Microsoft.Extensions.Options;
+
+// Common layer
+using Backend.Common.Services;
+
+// Domain layer
+using Backend.Domain.Abstractions;
+
+// Application layer
+using Backend.Application.Abstractions.Infrastructure.Data;
+using Backend.Application.Abstractions.Infrastructure.Email;
+
+using Backend.Application.Abstractions.Infrastructure.RateLimiting;
+using Backend.Application.Abstractions.Infrastructure.Security;
+using Backend.Application.Abstractions.Infrastructure.System;
+using Backend.Application.Abstractions.Infrastructure.WebSockets;
+using Backend.Infrastructure.BackgroundServices;
+using Backend.Infrastructure.Data.Sql.Factories;
+using Backend.Infrastructure.Data.Sql.Interfaces.Factories;
+using Backend.Infrastructure.Email;
+using Backend.Infrastructure.Identity;
+using Backend.Infrastructure.Implementations;
+using Backend.Infrastructure.Repositories.Auth;
+using Backend.Infrastructure.Repositories.Auth.RefreshTokens;
+using Backend.Infrastructure.Repositories.Auth.VerificationTokens;
+using Backend.Infrastructure.Repositories.Budget;
+using Backend.Infrastructure.Repositories.Email;
+using Backend.Infrastructure.Repositories.User;
+using Backend.Infrastructure.Security;
+using Backend.Settings;
+using Backend.Settings.Email;
+
+namespace Backend.Infrastructure;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddInfrastructureServices(this IServiceCollection services, IConfiguration configuration, bool isProduction)
+    {
+        #region settings
+        // Configure the ExpiredTokenScannerSettings
+        services.Configure<ExpiredTokenScannerSettings>(
+            configuration.GetSection("ExpiredTokenScannerSettings"));
+
+        // Configure the WebSocketHealthCheckSettings
+        services.Configure<WebSocketHealthCheckSettings>(
+            configuration.GetSection("WebSocketHealthCheckSettings"));
+
+        // Configure the JWT settings
+        var jwtSettingsSection = configuration.GetSection("JwtSettings");
+
+        // DB settings
+        services.Configure<DatabaseSettings>(configuration.GetSection("DatabaseSettings"));
+
+        // Email settings (Smtp)
+        services.Configure<SmtpSettings>(configuration.GetSection("Smtp"));
+
+        services.Configure<DatabaseSettings>(configuration.GetSection("DatabaseSettings"));
+        #endregion
+
+
+        // Caching
+        if (isProduction)
+        {
+            services.AddStackExchangeRedisCache(options =>
+            {
+                options.Configuration = configuration.GetSection("Redis")["ConnectionString"];
+                options.InstanceName = "eBudget:";
+            });
+            services.AddScoped<ITokenBlacklistService, TokenBlacklistService>();
+        }
+        else
+        {
+            services.AddDistributedMemoryCache();
+            services.AddScoped<ITokenBlacklistService, NoopBlacklistService>();
+        }
+
+        // Section for SQL related services
+        // Connection factory
+        services.AddScoped<IConnectionFactory>(provider =>
+        {
+            var settings = provider.GetRequiredService<IOptions<DatabaseSettings>>().Value;
+            if (string.IsNullOrEmpty(settings.ConnectionString))
+            {
+                throw new InvalidOperationException("Database connection string not found in configuration.");
+            }
+            return new MySqlConnectionFactory(settings.ConnectionString);
+        });
+        // Unit of Work
+        services.AddScoped<IUnitOfWork, UnitOfWork>();
+
+        // Contexts
+        services.AddScoped<ICurrentUserContext, HttpCurrentUserContext>();
+
+        // Repositories
+        // Budget
+        services.AddScoped<IBudgetRepository, BudgetRepository>();
+        services.AddScoped<IDebtsRepository, DebtsRepository>();
+        services.AddScoped<IExpenditureRepository, ExpenditureRepository>();
+        services.AddScoped<IIncomeRepository, IncomeRepository>();
+        services.AddScoped<ISavingsRepository, SavingsRepository>();
+
+        // User
+        services.AddScoped<IUserRepository, UserRepository>();
+        services.AddScoped<IUserAuthenticationRepository, UserAuthenticationRepository>();
+
+        // Recaptcha service
+        services.AddHttpClient<IRecaptchaService, RecaptchaService>();
+
+        // Section for email services
+        services.AddScoped<IEmailRateLimitRepository, EmailRateLimitRepository>();
+        services.AddScoped<IEmailRateLimiter, EmailRateLimiter>();
+        services.AddScoped<IEmailService, EmailService>();
+
+        // Other various services
+        services.AddScoped<ITimeProvider, Backend.Common.Services.TimeProvider>();
+        services.AddScoped<ICookieService, CookieService>();
+
+        // JWT Service
+        services.AddScoped<IJwtService, JwtService>();
+        services.AddScoped<IRefreshTokenRepository, RefreshTokenRepository>();
+
+        // Verification Token Repository
+        services.AddScoped<IVerificationTokenRepository, VerificationTokenRepository>();
+
+        // Add WebSockets and their helpers
+        services.AddSingleton<IWebSocketManager, Backend.Infrastructure.WebSockets.WebSocketManager>();
+        //services.AddHostedService(provider => (Backend.Infrastructure.WebSockets.WebSocketManager)provider.GetRequiredService<IWebSocketManager>());
+
+        // Background services
+        services.AddHostedService<ExpiredTokenScanner>();
+        services.AddHostedService<WebSocketHealthCheckService>();
+
+
+        return services;
+    }
+}

--- a/Backend/Infrastructure/Repositories/User/UserRepository.cs
+++ b/Backend/Infrastructure/Repositories/User/UserRepository.cs
@@ -18,8 +18,8 @@ public class UserRepository : SqlBase, IUserRepository
     public async Task<bool> CreateUserAsync(UserModel user, CancellationToken ct = default)
     {
         const string sql = @"
-            INSERT INTO users (PersoId, Firstname, Lastname, Email, Password, Roles, CreatedBy)
-            VALUES (@PersoId, @Firstname, @Lastname, @Email, @Password, @Roles, 'System');";
+            INSERT INTO Users (PersoId, Firstname, Lastname, Email, Password, Roles, EmailConfirmed, CreatedBy)
+            VALUES (@PersoId, @Firstname, @Lastname, @Email, @Password, @Roles, @EmailConfirmed, 'System');";
 
         _logger.LogInformation("Inserting user {Email}", user.Email);
         var rows = await ExecuteAsync(sql, new
@@ -29,7 +29,8 @@ public class UserRepository : SqlBase, IUserRepository
             user.LastName,
             user.Email,
             user.Password,
-            user.Roles
+            user.Roles,
+            user.EmailConfirmed
         }, ct);
         _logger.LogInformation("Insert completed. Rows affected: {Rows}", rows);
         return rows == 1;
@@ -38,7 +39,8 @@ public class UserRepository : SqlBase, IUserRepository
     public async Task<bool> ConfirmUserEmailAsync(Guid persoid, CancellationToken ct = default)
     {
         const string sql = "UPDATE Users SET EmailConfirmed = 1 WHERE PersoId = @PersoId;";
-        return await QueryFirstOrDefaultAsync<bool>(sql, new { PersoId = persoid }, ct);
+        var rows = await ExecuteAsync(sql, new { PersoId = persoid }, ct);
+        return rows > 0;
     }
     public Task<UserModel?> GetUserModelAsync(Guid? persoid = null, string? email = null, CancellationToken ct = default)
     {

--- a/SteenBudgetSolution.sln
+++ b/SteenBudgetSolution.sln
@@ -13,6 +13,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Backend.IntegrationTests", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Backend.UnitTests", "tests\Backend.UnitTests\Backend.UnitTests.csproj", "{8934D066-3143-443F-8924-7EECA2CCA524}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Backend.Tools", "Backend.Tools\Backend.Tools.csproj", "{055EA0DE-00E7-4B35-884E-29594F2104B4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -35,6 +37,10 @@ Global
 		{8934D066-3143-443F-8924-7EECA2CCA524}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8934D066-3143-443F-8924-7EECA2CCA524}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8934D066-3143-443F-8924-7EECA2CCA524}.Release|Any CPU.Build.0 = Release|Any CPU
+		{055EA0DE-00E7-4B35-884E-29594F2104B4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{055EA0DE-00E7-4B35-884E-29594F2104B4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{055EA0DE-00E7-4B35-884E-29594F2104B4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{055EA0DE-00E7-4B35-884E-29594F2104B4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/database/init/01-full-schema.sql
+++ b/database/init/01-full-schema.sql
@@ -82,13 +82,13 @@ CREATE TABLE UserVerificationTracking (
 -- ####################################################################
 -- # SECTION 1.1: EMAIL TABLES
 -- ####################################################################
-CREATE TABLE IF NOT EXISTS email_send_limits (
-    user_id BINARY(16) NOT NULL,
-    email_kind TINYINT UNSIGNED NOT NULL,
-    `date` DATE NOT NULL,            -- UTC date bucket
-    sent_count INT UNSIGNED NOT NULL DEFAULT 0,
-    last_sent_at DATETIME(6) NOT NULL,
-    PRIMARY KEY (user_id, email_kind, `date`)
+CREATE TABLE IF NOT EXISTS Email_send_limits (
+    User_id BINARY(16) NOT NULL,
+    Email_kind TINYINT UNSIGNED NOT NULL,
+    `Date` DATE NOT NULL,            -- UTC date bucket
+    Sent_count INT UNSIGNED NOT NULL DEFAULT 0,
+    Last_sent_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (User_id, Email_kind, `Date`)
 ) ENGINE=InnoDB;
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,25 +7,22 @@ volumes:
   caddy_data:
   caddy_config:
 
+
 services:
   mariadb:
     image: mariadb:11.4.2
-    ports:
-      - "127.0.0.1:3306:3306" 
-    environment:
-      MARIADB_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
-      MARIADB_DATABASE: ${MARIADB_DATABASE}
-      MARIADB_USER: ${DB_USER}
-      MARIADB_PASSWORD: ${DB_PASSWORD}
-    command: ["--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci"]
+    env_file:
+      - .env.prod # ← DB_ROOT_PASSWORD, DB_APP_USER, DB_APP_PASSWORD, MARIADB_DATABASE
+    command: [ "--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci" ]
     volumes:
-      - ./database/init:/docker-entrypoint-initdb.d:ro 
+      - ./database/init:/docker-entrypoint-initdb.d:ro
       - mariadb_data:/var/lib/mysql
     healthcheck:
-      test: ["CMD-SHELL", "mariadb-admin ping -uroot -p${DB_ROOT_PASSWORD} --silent"]
+      test: [ "CMD-SHELL", "mariadb-admin ping -uroot -p$$MARIADB_ROOT_PASSWORD --silent" ]
       interval: 10s
-      timeout: 3s
-      retries: 10
+      timeout: 5s
+      start_period: 60s
+      retries: 20
     restart: unless-stopped
     networks:
       - steen
@@ -34,24 +31,23 @@ services:
 
   backend:
     image: ghcr.io/lsteen89/steenbudget-backend:latest
-    env_file: .env                 # ← JWT_SECRET_KEY, DATABASESETTINGS__CONNECTIONSTRING, WEBSOCKET_SECRET, etc.
-    environment:
-      JwtSettings__SecretKey: ${JWT_SECRET_KEY:?set JWT_SECRET_KEY in .env}
+    env_file:
+      - .env.prod # contains JwtSettings__SecretKey, DatabaseSettings__ConnectionString, WEBSOCKET_SECRET, RECAPTCHA_SECRET_KEY
     depends_on:
       mariadb:
         condition: service_healthy
     restart: unless-stopped
     networks:
       - steen
-    pull_policy: always            # ← always pull the latest image
+    pull_policy: always # ← always pull the latest image
     labels:
       - com.centurylinklabs.watchtower.enable=false
 
   caddy:
     image: ghcr.io/lsteen89/caddy-cloudflare:2.9.1
-    pull_policy: missing                                           # ← don’t pull if already present
-    environment:
-      CLOUDFLARE_API_TOKEN: ${CLOUDFLARE_API_TOKEN:?set CLOUDFLARE_API_TOKEN}
+    pull_policy: missing # ← don’t pull if already present
+    env_file:
+      - .env.prod # includes CLOUDFLARE_API_TOKEN
     ports:
       - "80:80"
       - "443:443"
@@ -64,9 +60,9 @@ services:
       backend:
         condition: service_healthy
     restart: unless-stopped
-    networks: [steen]
+    networks: [ steen ]
     labels:
-      - com.centurylinklabs.watchtower.enable=false   # ← disable watchtower for Caddy
+      - com.centurylinklabs.watchtower.enable=false # ← disable watchtower for Caddy
 
   watchtower:
     image: containrrr/watchtower


### PR DESCRIPTION
…asing & email confirm persistence

- Backend.Tools:
  - Add dev-only seeding path (Noop reCAPTCHA, DI validation disabled).
  - Override IUnitOfWork in Tools to provide a real MySqlConnection from config.
  - Fail fast if DB connection string is missing (prevents Dapper NREs).
  - Keep seeding behind ALLOW_SEEDING=true.

- Infrastructure/Repositories:
  - Use `INSERT INTO Users` (Linux/MariaDB case-sensitive).
  - Persist `EmailConfirmed` in INSERT so seeded users are verified immediately.
  - Change `ConfirmUserEmailAsync` to `UPDATE ... AND EmailConfirmed = 0` + `ExecuteAsync`.

- Dev compose:
  - Add `seed-users` one-shot service (SDK image).
  - Builds & runs Backend.Tools inside the container; depends on db health.
  - Pass SEED_* via env; escape with `$$` so expansion happens in-container.
  - Uses repo bind mount; no image churn; runs automatically on `up`.

- .env.dev:
  - Ensure `DATABASESETTINGS__CONNECTIONSTRING=Server=db;Port=3306;Database=steenbudgetDEV;User=app;Password=apppwd;Connection Timeout=3;Default Command Timeout=3;GuidFormat=Binary16;OldGuids=false`.

Notes:
- Dev-only; not present in prod compose.
- Table name casing standardized to `Users` everywhere.

test:
- `docker compose -f docker-compose.dev.yml down --remove-orphans`
- `docker compose -f docker-compose.dev.yml up -d --build`
- `docker logs -f steenbudget-seeder-dev` → should show "Insert completed. Rows affected: 1" or idempotent behavior
- Verify: `SELECT BIN_TO_UUID(PersoId), Email, EmailConfirmed FROM Users WHERE Email='l@l.se';`

refactor(warning): annotate JwtService/TokenBlacklistService as obsolete; no runtime behavior change