### PR TITLE
Email via Postmark + contact endpoint (rate-limited)

### DIFF
--- a/Backend/Application/Abstractions/Infrastructure/Email/IEmailRateLimitRepository.cs
+++ b/Backend/Application/Abstractions/Infrastructure/Email/IEmailRateLimitRepository.cs
@@ -3,7 +3,7 @@ namespace Backend.Application.Abstractions.Infrastructure.Email;
 
 public interface IEmailRateLimitRepository
 {
-    Task<EmailRateLimitRow?> GetTodayAsync(byte[] keyHash, byte kind, DateOnly dateUtc, CancellationToken ct);
-    Task UpsertMarkSentAsync(byte[] keyHash, byte kind, DateOnly dateUtc, DateTime nowUtc, CancellationToken ct);
+    Task<EmailRateLimitRow?> GetTodayAsync(byte[] keyHash, byte kind, DateTime dayUtc, CancellationToken ct);
+    Task UpsertMarkSentAsync(byte[] keyHash, byte kind, DateTime dayUtc, DateTime lastSentAtUtc, CancellationToken ct);
     Task<int> CleanupAsync(int retentionDays, CancellationToken ct);
 }

--- a/Backend/Application/DTO/Email/SendContactFormRequest.cs
+++ b/Backend/Application/DTO/Email/SendContactFormRequest.cs
@@ -4,19 +4,11 @@ namespace Backend.Application.DTO.Email;
 
 public sealed class SendContactFormRequest
 {
-    [Required, EmailAddress, MaxLength(320)]
     public string SenderEmail { get; init; } = default!;
-
-    [Required, MaxLength(200)]
     public string Subject { get; init; } = default!;
-
-    [Required, MaxLength(4000)]
     public string Body { get; init; } = default!;
-
-    [Required]
     public string CaptchaToken { get; init; } = default!;
 
-    // Keep only if you use them in the email body/display:
     public string? FirstName { get; init; }
     public string? LastName { get; init; }
 }

--- a/Backend/Application/DependencyInjection.cs
+++ b/Backend/Application/DependencyInjection.cs
@@ -53,7 +53,6 @@ public static class DependencyInjection
         services.AddScoped<IWizardStepProcessor, SavingsStepProcessor>();
 
         //Wizard Validation
-        services.AddValidatorsFromAssemblyContaining<IncomeValidator>();
 
         return services;
     }

--- a/Backend/Application/Features/Contact/SendContactFormCommandHandler.cs
+++ b/Backend/Application/Features/Contact/SendContactFormCommandHandler.cs
@@ -35,7 +35,7 @@ public sealed class SendContactFormHandler : ICommandHandler<SendContactFormComm
         _clock = clock;
         _smtpSettings = smtpSettings;
         _logger = logger;
-        _allowTestEmails = configuration.GetValue<bool>("AllowTestEmails");
+        _allowTestEmails = configuration.GetValue<bool>("ALLOW_TEST_EMAILS");
     }
 
     public async Task<Result> Handle(SendContactFormCommand request, CancellationToken ct)

--- a/Backend/Backend.csproj
+++ b/Backend/Backend.csproj
@@ -64,6 +64,7 @@
     <PackageReference Include="MySqlConnector" Version="2.3.7" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Polly" Version="8.6.2" />
+    <PackageReference Include="Postmark" Version="5.2.0" />
     <PackageReference Include="Serilog" Version="4.0.2" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />

--- a/Backend/Domain/Entities/Email/EmailMessageModel.cs
+++ b/Backend/Domain/Entities/Email/EmailMessageModel.cs
@@ -11,6 +11,7 @@ namespace Backend.Domain.Entities.Email
         ContactUs,
         ResetPassword
     }
+    [Obsolete("This class is obsolete. Not used.")]
     public class EmailMessageModel
     {
         public required string Recipient { get; set; }  // Recipient email

--- a/Backend/Infrastructure/DependencyInjection.cs
+++ b/Backend/Infrastructure/DependencyInjection.cs
@@ -118,7 +118,8 @@ public static class DependencyInjection
         // Section for email services
         services.AddScoped<IEmailRateLimitRepository, EmailRateLimitRepository>();
         services.AddScoped<IEmailRateLimiter, EmailRateLimiter>();
-        services.AddScoped<IEmailService, EmailService>();
+
+
 
         // Other various services
         services.AddSingleton<ITimeProvider, Backend.Common.Services.TimeProvider>();

--- a/Backend/Infrastructure/Email/EmailRateLimiter.cs
+++ b/Backend/Infrastructure/Email/EmailRateLimiter.cs
@@ -40,8 +40,8 @@ public sealed class EmailRateLimiter : IEmailRateLimiter
     private async Task<RateLimitDecision> CheckCoreAsync(byte[] keyHash, EmailKind kind, CancellationToken ct)
     {
         var now = _clock.UtcNow;
-        var today = DateOnly.FromDateTime(now);
-        var row = await _repo.GetTodayAsync(keyHash, (byte)kind, today, ct);
+        var todayUtc = now.Date;
+        var row = await _repo.GetTodayAsync(keyHash, (byte)kind, todayUtc, ct);
         if (row is null) return new(true);
 
         if (row.SentCount >= _opt.DailyLimit) return new(false, $"daily_limit:{_opt.DailyLimit}");
@@ -52,7 +52,7 @@ public sealed class EmailRateLimiter : IEmailRateLimiter
     }
 
     private Task MarkCoreAsync(byte[] keyHash, EmailKind kind, DateTimeOffset at, CancellationToken ct)
-        => _repo.UpsertMarkSentAsync(keyHash, (byte)kind, DateOnly.FromDateTime(at.UtcDateTime), at.UtcDateTime, ct);
+        => _repo.UpsertMarkSentAsync(keyHash, (byte)kind, at.UtcDateTime.Date, at.UtcDateTime, ct);
 
     // Helpers
     private static string Normalize(string s) => s.Trim().ToLowerInvariant();

--- a/Backend/Infrastructure/Email/Postmark/PostmarkEmailService.cs
+++ b/Backend/Infrastructure/Email/Postmark/PostmarkEmailService.cs
@@ -1,0 +1,68 @@
+using PostmarkDotNet;
+using Microsoft.Extensions.Options;
+using Backend.Application.Abstractions.Infrastructure.Email;
+using Backend.Settings.Email;
+
+namespace Backend.Infrastructure.Email.Postmark;
+
+public sealed class PostmarkEmailService : IEmailService
+{
+    private readonly PostmarkClient _client;
+    private readonly string _from;
+    private readonly string? _overrideTo;
+    private readonly string _stream;
+    private readonly bool _testMode;
+    private readonly ILogger<PostmarkEmailService> _log;
+
+    public PostmarkEmailService(IOptionsMonitor<PostmarkOptions> pm,
+                                IOptions<SmtpSettings> smtp,
+                                ILogger<PostmarkEmailService> log)
+    {
+        var p = pm.CurrentValue;
+        _client = new PostmarkClient(p.ServerToken);
+        _from = p.From ?? smtp.Value.FromAddress;
+        _overrideTo = (Environment.GetEnvironmentVariable("Email__OverrideTo")
+                      ?? (pm as IOptions<PostmarkOptions>)?.Value?.OverrideTo);
+        _stream = p.MessageStream ?? "outbound";
+        _testMode = p.TestMode;
+        _log = log;
+    }
+
+    public async Task<EmailSendResult> SendEmailAsync(IEmailComposer composer, CancellationToken ct)
+    {
+        var m = composer.Compose(); // your MailMessage/MimeMessage → map fields
+        var to = string.IsNullOrWhiteSpace(_overrideTo) ? m.To.ToString() : _overrideTo;
+
+        var req = new PostmarkMessage
+        {
+            From = _from,
+            To = to,
+            Subject = m.Subject,
+            HtmlBody = m.HtmlBody, // or map from your composer
+            TextBody = m.TextBody,
+            MessageStream = _stream,
+            TrackOpens = false,
+            Headers = _overrideTo is null ? null : new() {
+                new("X-Original-To", m.To.ToString())
+            }
+        };
+
+        if (_testMode) req.Headers ??= new(); // tag test mode (optional)
+        var resp = await _client.SendMessageAsync(req);
+        var ok = resp.Status == PostmarkStatus.Success;
+
+        if (!ok) _log.LogWarning("Postmark send failed: {Code} {Msg}", resp.ErrorCode, resp.Message);
+        else _log.LogInformation("Postmark sent: {Id}", resp.MessageID);
+
+        return new EmailSendResult(ok, ok ? resp.MessageID.ToString() : null, ok ? null : resp.Message);
+    }
+}
+
+public class PostmarkOptions
+{
+    public string ServerToken { get; set; } = "";
+    public string From { get; set; } = "";
+    public string MessageStream { get; set; } = "outbound";
+    public bool TestMode { get; set; }
+    public string? OverrideTo { get; set; }
+}

--- a/Backend/Settings/Email/SmtpSettings.cs
+++ b/Backend/Settings/Email/SmtpSettings.cs
@@ -1,8 +1,8 @@
 namespace Backend.Settings.Email;
 
-    /// <summary>
-    /// SmtpSettings class that holds the configuration for SMTP email settings.
-    /// </summary>
+/// <summary>
+/// SmtpSettings class that holds the configuration for SMTP email settings.
+/// </summary>
 
 public class SmtpSettings
 {
@@ -12,4 +12,5 @@ public class SmtpSettings
     public string Password { get; set; } = string.Empty;
     public string FromAddress { get; set; } = string.Empty;
     public string FromName { get; set; } = "Ebudget";
+    public string? ContactRecipient { get; set; }
 }

--- a/Backend/appsettings.Development.json
+++ b/Backend/appsettings.Development.json
@@ -39,11 +39,19 @@
   "AppSettings": {
     "BaseUrl": "https://localhost:5001"
   },
+  "Email": {
+    "Provider": "Postmark",
+    "OverrideTo": "dev-inbox@yourdomain.test"
+  },
+  "Postmark": {
+    "ServerToken": "__ENV__:POSTMARK_SERVER_TOKEN",
+    "From": "dev-no-reply@ebudget.se",
+    "MessageStream": "outbound",
+    "TestMode": true
+  },
   "Smtp": {
-    "Host": "localhost",
-    "Port": 1025,
-    "UsernameNoReply": "no-reply@localhost",
-    "UsernameInfoUser": "info@localhost"
+    "FromAddress": "no-reply@ebudget.test",
+    "FromName": "Ebudget"
   },
   "ResendEmailSettings": {
     "CooldownPeriodMinutes": 5,

--- a/database/init/01-full-schema.sql
+++ b/database/init/01-full-schema.sql
@@ -241,7 +241,7 @@ CREATE TABLE WizardStepData (
     CONSTRAINT FK_WizardStepData_WizardSession FOREIGN KEY (WizardSessionId) REFERENCES WizardSession(WizardSessionId) ON DELETE CASCADE
 ) ENGINE=InnoDB;
 
-CREATE TABLE IF NOT EXISTS EmailRateLimit (
+CREATE TABLE IF NOT EXISTS EmailRateLimits (
   KeyHash BINARY(32) NOT NULL,
   Kind TINYINT NOT NULL,
   DateUtc DATE NOT NULL,


### PR DESCRIPTION
Summary

Switch email sending to Postmark in prod; keep SMTP for dev.

Add POST /api/email/contact endpoint with rate limiting and optional dev CAPTCHA bypass.

Introduce composers (ContactFormEmailComposer, VerificationEmailComposer) behind IEmailService.

Changes

Added PostmarkEmailService (default in prod) + retained SmtpEmailService (dev).

DI toggle via Email:Provider = Postmark | Smtp.

Implemented EmailRateLimiter + repo; table EmailRateLimits (KeyHash, Kind, DateUtc, SentCount, LastSentAtUtc).

Clean logging & retries; secrets moved to env/user-secrets (no tokens in repo).